### PR TITLE
refactor: kt 환경에서 JPA CustomId 전략 변경

### DIFF
--- a/.github/technical/jpa.md
+++ b/.github/technical/jpa.md
@@ -1,41 +1,41 @@
 # Java Persistence API
 
-## 1. Open
-### 1. 문제점
+## 🧩 1. Kotlin + JPA
+
+## 💥 2. TroubleShooting
+### 1. Open
+#### 1. 문제점
 1. JPA Entity는 런타임에 Proxy로 생성해서 사용한다.
 2. Kotlin은 클래스, 메소드 기본이 final이다.
 3. 이 둘은 상충하는 문제다.
-### 2. 해결
+#### 2. 해결
 ```kotlin
 kotlin("plugin.spring") version "2.0.10" apply false
 kotlin("plugin.jpa") version "2.0.10" apply false
 ```
 - 위 플러그인으로 `@Entity`의 경우 open 시켜서 처리를 했다.
-
-
-## 2. val? var?
-### 1. 문제점
+### 2. val? var?
+#### 1. 문제점
 1. JPA는 지연로딩, 더티체킹을 사용하기 위해서 `mutable`해야 한다.
 2. Kotlin은 기본적으로 `immutable`함을 지향한다.
 3. 이 둘은 상충되는 개념이다.
-### 2. 해결
+#### 2. 해결
 1. JPAEntity는 var로 둔다.
 2. 대신 실질적으로 도메인 로직, 비즈니스 로직을 다루는 DomainEntity를 val로 두고 사용한다.
-
-## 3. 빈 생성자
-### 1. 문제점
+#### 3. 빈 생성자
+##### 1. 문제점
 1. JPA는 리플렉션을 바탕으로 동작한다.
 2. 리플렉션을 통해서 주입하기 위해서는 빈 생성자가 필요하다.
 3. kotlin은 PrimaryConstructor를 통해서 프로퍼티를 표현하는 경우가 있다.
 
-### 2. 해결
+#### 2. 해결
 ```kotlin
 kotlin("plugin.jpa") version "2.0.10" apply false
 ```
 1. 위와 같은 플러그인으로 빈 생성자를 암묵적으로 제공받는다.
 2. primaryConstructor를 두고 보조 생성자로 정의한다.
 
-----
-## +⍺ JPA와 Kotlin 어울리는건가요?
+----------
+### +⍺ JPA와 Kotlin 어울리는건가요?
 - 솔직히 위 두 문제만으로 JPA와 Kotlin은 궁합이 안맞는게 아닌가? 라는 생각이 들었다.
 - 이런 상황에서 `Expose`나 이전에 사용하던 `jooq`를 사용하는 게 어떤가 하는 의문이 들었다.

--- a/.github/technical/jpa.md
+++ b/.github/technical/jpa.md
@@ -1,6 +1,106 @@
 # Java Persistence API
 
-## 🧩 1. Kotlin + JPA
+## 🧩 1. Kotlin + JPA의 Custom ID 전략
+### 0.  🔑 UUID 사용 이유
+#### 장점
+- 전역적으로 유일한 값을 보장할 수 있다.
+- 분산 환경에서 안전한 ID를 생성할 수 있다.
+- 보안적으로 예측이 불가하기 때문에 보안성을 향상시켜준다.
+- TimeBase-UUID: 사용 시 정렬성까지 갖출 수 있다.
+#### 단점
+- 너무 길다 따라서 인덱스 단편화를 발생시킬 수도 있다.
+- 스토리지 낭비가 있다.
+- 비즈니스적으로 의미가 없는 값이다.
+
+#### UUID 선택 이유
+- 운영 유연성: MicroService 환경 등에서 충돌 걱정이 없음
+- 보안: 난독화된 식별자로 예측 방지
+- 정렬성: Timebased로 일부 성능 이슈 해소가 가능하다.
+
+### 1. Kt에서 @IdGeneratorType
+
+#### 1. kt val 정책
+```kotlin
+////////// annotation
+import org.hibernate.annotations.IdGeneratorType
+
+@IdGeneratorType(TimeBasedIdGenerator::class)
+@Retention(AnnotationRetention.RUNTIME)
+@Target(AnnotationTarget.FIELD)
+annotation class TimeBasedUuidStrategy
+
+////////// 실제 생성
+        
+class TimeBasedIdGenerator : IdentifierGenerator {
+    override fun generate(
+        p0: SharedSessionContractImplementor?,
+        p1: Any?,
+    ): String {
+        return UuidGenerator.generate()
+    }
+}
+
+/////// 사용처
+
+@Id
+@TimeBasedUuidStrategy
+@Column(name = "id", columnDefinition = "VARCHAR(128)", nullable = false, updatable = false)
+@Comment("식별키")
+val id: String? = null
+```
+
+- 기본적으로 불변 필드를 주 생성자에 정의하는 것이 일반적이다.
+- Hibernate는 Java에서 Setter, Reflection을 사용해서 ID를 주입하려고 한다.
+- 하지만 id로 잡은 주 생성자에 넣은 필드는 setter가 없고 reflection 제한이 있다. -> Runtime Error를 발생시킨다.
+
+#### 2. kt에 맞는 상속 기반 id 전략
+```kotlin
+@MappedSuperclass
+abstract class TimeBasedPrimaryKey : Persistable<String> {
+    @Id
+    @Column(name = "id", columnDefinition = "VARCHAR(128)", nullable = false, updatable = false)
+    @Comment("식별키")
+    val id: String = UuidGenerator.generate()
+
+    @Transient
+    private var isNewEntity: Boolean = true
+
+    override fun getId(): String? = id
+
+    override fun isNew(): Boolean = isNewEntity
+
+    override fun hashCode(): Int = Objects.hashCode(id)
+
+    override fun equals(other: Any?): Boolean {
+        if (other == null) {
+            return false
+        }
+
+        if (other !is HibernateProxy && this::class != other::class) {
+            return false
+        }
+
+        return id == getIdentifier(other)
+    }
+
+    private fun getIdentifier(obj: Any): Serializable {
+        return if (obj is HibernateProxy) {
+            obj.hibernateLazyInitializer.identifier as Serializable
+        } else {
+            (obj as TimeBasedPrimaryKey).id
+        }
+    }
+
+    @PostPersist
+    @PostLoad
+    protected fun load() {
+        isNewEntity = false
+    }
+}
+```
+- 직접 equals/hashcode 구현, isNew 판별을 진행합니다.
+- UUID를 곧바로 생성하므로 JPA save가 merge할 가능성이 있다.
+- 즉, hibernate 버그, reflection을 명시적으로 회피하고 직접 생성 방식으로 처리한다.
 
 ## 💥 2. TroubleShooting
 ### 1. Open

--- a/.github/workflows/publish-test-result.yaml
+++ b/.github/workflows/publish-test-result.yaml
@@ -5,6 +5,7 @@ on:
 
 jobs:
   publish_test_results:
+    if: always()
     runs-on: ubuntu-latest
     steps:
       - name: Download adapter test-results

--- a/adapter-module/src/main/kotlin/com/reservation/persistence/common/TimeBasedPrimaryKey.kt
+++ b/adapter-module/src/main/kotlin/com/reservation/persistence/common/TimeBasedPrimaryKey.kt
@@ -1,0 +1,56 @@
+package com.reservation.persistence.common
+
+import com.reservation.utilities.generator.uuid.UuidGenerator
+import jakarta.persistence.Column
+import jakarta.persistence.Id
+import jakarta.persistence.MappedSuperclass
+import jakarta.persistence.PostLoad
+import jakarta.persistence.PostPersist
+import org.hibernate.annotations.Comment
+import org.hibernate.proxy.HibernateProxy
+import org.springframework.data.domain.Persistable
+import java.io.Serializable
+import java.util.Objects
+
+@MappedSuperclass
+abstract class TimeBasedPrimaryKey : Persistable<String> {
+    @Id
+    @Column(name = "id", columnDefinition = "VARCHAR(128)", nullable = false, updatable = false)
+    @Comment("식별키")
+    val id: String = UuidGenerator.generate()
+
+    @Transient
+    private var isNewEntity: Boolean = true
+
+    override fun getId(): String? = id
+
+    override fun isNew(): Boolean = isNewEntity
+
+    override fun hashCode(): Int = Objects.hashCode(id)
+
+    override fun equals(other: Any?): Boolean {
+        if (other == null) {
+            return false
+        }
+
+        if (other !is HibernateProxy && this::class != other::class) {
+            return false
+        }
+
+        return id == getIdentifier(other)
+    }
+
+    private fun getIdentifier(obj: Any): Serializable {
+        return if (obj is HibernateProxy) {
+            obj.hibernateLazyInitializer.identifier as Serializable
+        } else {
+            (obj as TimeBasedPrimaryKey).id
+        }
+    }
+
+    @PostPersist
+    @PostLoad
+    protected fun load() {
+        isNewEntity = false
+    }
+}

--- a/adapter-module/src/main/kotlin/com/reservation/persistence/common/TimeBasedPrimaryKey.kt
+++ b/adapter-module/src/main/kotlin/com/reservation/persistence/common/TimeBasedPrimaryKey.kt
@@ -17,16 +17,16 @@ abstract class TimeBasedPrimaryKey : Persistable<String> {
     @Id
     @Column(name = "id", columnDefinition = "VARCHAR(128)", nullable = false, updatable = false)
     @Comment("식별키")
-    val id: String = UuidGenerator.generate()
+    val identifier: String = UuidGenerator.generate()
 
     @Transient
     private var isNewEntity: Boolean = true
 
-    override fun getId(): String? = id
+    override fun getId(): String? = this.identifier
 
-    override fun isNew(): Boolean = isNewEntity
+    override fun isNew(): Boolean = this.isNewEntity
 
-    override fun hashCode(): Int = Objects.hashCode(id)
+    override fun hashCode(): Int = Objects.hashCode(identifier)
 
     override fun equals(other: Any?): Boolean {
         if (other == null) {
@@ -37,14 +37,14 @@ abstract class TimeBasedPrimaryKey : Persistable<String> {
             return false
         }
 
-        return id == getIdentifier(other)
+        return identifier == getIdentifier(other)
     }
 
     private fun getIdentifier(obj: Any): Serializable {
         return if (obj is HibernateProxy) {
             obj.hibernateLazyInitializer.identifier as Serializable
         } else {
-            (obj as TimeBasedPrimaryKey).id
+            (obj as TimeBasedPrimaryKey).identifier
         }
     }
 

--- a/adapter-module/src/main/kotlin/com/reservation/persistence/company/entity/CompanyEntity.kt
+++ b/adapter-module/src/main/kotlin/com/reservation/persistence/company/entity/CompanyEntity.kt
@@ -1,9 +1,8 @@
 package com.reservation.persistence.company.entity
 
-import com.reservation.config.persistence.entity.TimeBasedUuidStrategy
+import com.reservation.persistence.common.TimeBasedPrimaryKey
 import jakarta.persistence.Column
 import jakarta.persistence.Entity
-import jakarta.persistence.Id
 import jakarta.persistence.Table
 import org.hibernate.annotations.Comment
 
@@ -19,13 +18,7 @@ class CompanyEntity(
     address: String,
     detail: String,
     representativeName: String,
-) {
-    @Id
-    @TimeBasedUuidStrategy
-    @Column(name = "id", columnDefinition = "VARCHAR(128)", nullable = false, updatable = false)
-    @Comment("식별키")
-    val id: String? = null
-
+) : TimeBasedPrimaryKey() {
     @Column(name = "brand_name")
     @Comment("상호명")
     var brandName: String = brandName

--- a/adapter-module/src/main/kotlin/com/reservation/persistence/company/repository/dsl/FindCompanies.kt
+++ b/adapter-module/src/main/kotlin/com/reservation/persistence/company/repository/dsl/FindCompanies.kt
@@ -16,7 +16,7 @@ class FindCompanies(
         return query.select(
             Projections.constructor(
                 FindCompaniesQueryResult::class.java,
-                companyEntity.id,
+                companyEntity.identifier,
                 companyEntity.brandName,
                 companyEntity.brandUrl,
                 companyEntity.representativeName,

--- a/adapter-module/src/main/kotlin/com/reservation/persistence/user/entity/UserAccessHistoryEntity.kt
+++ b/adapter-module/src/main/kotlin/com/reservation/persistence/user/entity/UserAccessHistoryEntity.kt
@@ -1,10 +1,9 @@
 package com.reservation.persistence.user.entity
 
-import com.reservation.config.persistence.entity.TimeBasedUuidStrategy
 import com.reservation.enumeration.AccessStatus
+import com.reservation.persistence.common.TimeBasedPrimaryKey
 import jakarta.persistence.Column
 import jakarta.persistence.Entity
-import jakarta.persistence.Id
 import jakarta.persistence.Table
 import org.hibernate.annotations.Comment
 import java.time.LocalDateTime
@@ -18,13 +17,7 @@ class UserAccessHistoryEntity(
     userId: String,
     accessStatus: AccessStatus,
     accessDatetime: LocalDateTime,
-) {
-    @Id
-    @TimeBasedUuidStrategy
-    @Column(name = "id", columnDefinition = "VARCHAR(128)", nullable = false, updatable = false)
-    @Comment("식별키")
-    val id: String? = null
-
+) : TimeBasedPrimaryKey() {
     @Column(name = "user_uuid", columnDefinition = "VARCHAR(128)")
     @Comment("식별키")
     val userUuid: String = userId

--- a/adapter-module/src/main/kotlin/com/reservation/persistence/user/entity/UserChangeHistoryEntity.kt
+++ b/adapter-module/src/main/kotlin/com/reservation/persistence/user/entity/UserChangeHistoryEntity.kt
@@ -1,14 +1,13 @@
 package com.reservation.persistence.user.entity
 
-import com.reservation.config.persistence.entity.TimeBasedUuidStrategy
 import com.reservation.enumeration.Role
 import com.reservation.persistence.common.AuditDateTime
+import com.reservation.persistence.common.TimeBasedPrimaryKey
 import jakarta.persistence.Column
 import jakarta.persistence.Embedded
 import jakarta.persistence.Entity
 import jakarta.persistence.EnumType
 import jakarta.persistence.Enumerated
-import jakarta.persistence.Id
 import jakarta.persistence.Table
 import org.hibernate.annotations.Comment
 
@@ -24,13 +23,7 @@ class UserChangeHistoryEntity(
     nickname: String,
     mobile: String,
     role: Role,
-) {
-    @Id
-    @TimeBasedUuidStrategy
-    @Column(name = "id", columnDefinition = "VARCHAR(128)", nullable = false, updatable = false)
-    @Comment("식별키")
-    val id: String? = null
-
+) : TimeBasedPrimaryKey() {
     @Column(
         name = "user_uuid",
         columnDefinition = "VARCHAR(128)",

--- a/adapter-module/src/main/kotlin/com/reservation/persistence/user/entity/UserEntity.kt
+++ b/adapter-module/src/main/kotlin/com/reservation/persistence/user/entity/UserEntity.kt
@@ -1,15 +1,14 @@
 package com.reservation.persistence.user.entity
 
-import com.reservation.config.persistence.entity.TimeBasedUuidStrategy
 import com.reservation.enumeration.Role
 import com.reservation.enumeration.UserStatus
 import com.reservation.persistence.common.AuditDateTime
+import com.reservation.persistence.common.TimeBasedPrimaryKey
 import jakarta.persistence.Column
 import jakarta.persistence.Embedded
 import jakarta.persistence.Entity
 import jakarta.persistence.EnumType
 import jakarta.persistence.Enumerated
-import jakarta.persistence.Id
 import jakarta.persistence.Index
 import jakarta.persistence.Table
 import org.hibernate.annotations.Comment
@@ -30,13 +29,7 @@ class UserEntity(
     nickname: String,
     mobile: String,
     role: Role,
-) {
-    @Id
-    @TimeBasedUuidStrategy
-    @Column(name = "id", columnDefinition = "VARCHAR(128)", nullable = false, updatable = false)
-    @Comment("식별키")
-    val id: String? = null
-
+) : TimeBasedPrimaryKey() {
     @Column(
         name = "login_id",
         columnDefinition = "VARCHAR(32)",

--- a/adapter-module/src/main/kotlin/com/reservation/persistence/user/repository/adapter/self/CreateGeneralUserAdapter.kt
+++ b/adapter-module/src/main/kotlin/com/reservation/persistence/user/repository/adapter/self/CreateGeneralUserAdapter.kt
@@ -23,6 +23,6 @@ class CreateGeneralUserAdapter(
                 ),
             )
 
-        return entity.id != null
+        return entity.identifier != null
     }
 }

--- a/adapter-module/src/main/kotlin/com/reservation/persistence/user/repository/adapter/self/LoadGeneralUserAdapter.kt
+++ b/adapter-module/src/main/kotlin/com/reservation/persistence/user/repository/adapter/self/LoadGeneralUserAdapter.kt
@@ -13,7 +13,7 @@ class LoadGeneralUserAdapter(
         return jpaRepository.findById(id)
             .map {
                 LoadGeneralUserResult(
-                    it.id!!,
+                    it.identifier!!,
                     it.loginId,
                     it.password,
                     it.oldPassword,

--- a/adapter-module/src/main/kotlin/com/reservation/persistence/user/repository/adapter/self/LoadGeneralUserLoginIdAndEmailAdapter.kt
+++ b/adapter-module/src/main/kotlin/com/reservation/persistence/user/repository/adapter/self/LoadGeneralUserLoginIdAndEmailAdapter.kt
@@ -19,7 +19,7 @@ class LoadGeneralUserLoginIdAndEmailAdapter(
         )
             .map {
                 LoadGeneralUserByLoginIdAndEmailResult(
-                    it.id!!,
+                    it.identifier!!,
                     it.loginId,
                     it.password,
                     it.oldPassword,

--- a/adapter-module/src/main/kotlin/com/reservation/persistence/user/repository/dsl/AuthenticateUserRepository.kt
+++ b/adapter-module/src/main/kotlin/com/reservation/persistence/user/repository/dsl/AuthenticateUserRepository.kt
@@ -61,7 +61,7 @@ class AuthenticateUserRepository(
         return query.select(
             Projections.constructor(
                 Result::class.java,
-                userEntity.id,
+                userEntity.identifier,
                 userEntity.loginId,
                 userEntity.password,
                 userEntity.failCount,

--- a/adapter-module/src/main/kotlin/com/reservation/persistence/user/repository/dsl/CheckDuplicatedGeneralUserLoginIdRepository.kt
+++ b/adapter-module/src/main/kotlin/com/reservation/persistence/user/repository/dsl/CheckDuplicatedGeneralUserLoginIdRepository.kt
@@ -12,7 +12,7 @@ class CheckDuplicatedGeneralUserLoginIdRepository(
 ) : CheckGeneralUserLoginIdDuplicated {
     override fun query(inquiry: CheckGeneralUserDuplicatedInquiry): Boolean {
         return query.select(
-            userEntity.id,
+            userEntity.identifier,
         )
             .from(userEntity)
             .where(

--- a/adapter-module/src/main/kotlin/com/reservation/persistence/user/repository/dsl/CheckDuplicatedGeneralUserNicknameRepository.kt
+++ b/adapter-module/src/main/kotlin/com/reservation/persistence/user/repository/dsl/CheckDuplicatedGeneralUserNicknameRepository.kt
@@ -12,7 +12,7 @@ class CheckDuplicatedGeneralUserNicknameRepository(
 ) : CheckGeneralUserNicknameDuplicated {
     override fun query(inquiry: CheckGeneralUserNicknameDuplicatedInquiry): Boolean {
         return query.select(
-            userEntity.id,
+            userEntity.identifier,
         )
             .from(userEntity)
             .where(

--- a/adapter-module/src/main/kotlin/com/reservation/persistence/user/repository/dsl/CheckDuplicatedGeneralUserRepository.kt
+++ b/adapter-module/src/main/kotlin/com/reservation/persistence/user/repository/dsl/CheckDuplicatedGeneralUserRepository.kt
@@ -12,7 +12,7 @@ class CheckDuplicatedGeneralUserRepository(
 ) : CheckGeneralUserDuplicated {
     override fun query(inquiry: CheckGeneralUserDuplicatedInquiry): Boolean {
         return query.select(
-            userEntity.id,
+            userEntity.identifier,
         )
             .from(userEntity)
             .where(

--- a/adapter-module/src/main/kotlin/com/reservation/persistence/user/repository/dsl/FindGeneralUserRepository.kt
+++ b/adapter-module/src/main/kotlin/com/reservation/persistence/user/repository/dsl/FindGeneralUserRepository.kt
@@ -17,7 +17,7 @@ class FindGeneralUserRepository(
             .select(
                 Projections.constructor(
                     FindGeneralUserResult::class.java,
-                    userEntity.id,
+                    userEntity.identifier,
                     userEntity.loginId,
                     userEntity.email,
                     userEntity.nickname,

--- a/adapter-module/src/main/kotlin/com/reservation/persistence/user/repository/dsl/UserQuerySpec.kt
+++ b/adapter-module/src/main/kotlin/com/reservation/persistence/user/repository/dsl/UserQuerySpec.kt
@@ -11,7 +11,7 @@ object UserQuerySpec {
     fun idEq(id: String?): BooleanExpression? =
         id.let {
             if (StringUtils.hasText(id)) {
-                return@let userEntity.id.eq(it)
+                return@let userEntity.identifier.eq(it)
             }
 
             return@let null

--- a/adapter-module/src/main/kotlin/com/reservation/persistence/withdrawal/entity/WithdrawalUserEntity.kt
+++ b/adapter-module/src/main/kotlin/com/reservation/persistence/withdrawal/entity/WithdrawalUserEntity.kt
@@ -1,9 +1,8 @@
 package com.reservation.persistence.withdrawal.entity
 
-import com.reservation.config.persistence.entity.TimeBasedUuidStrategy
+import com.reservation.persistence.common.TimeBasedPrimaryKey
 import jakarta.persistence.Column
 import jakarta.persistence.Entity
-import jakarta.persistence.Id
 import jakarta.persistence.Table
 import org.hibernate.annotations.Comment
 
@@ -18,13 +17,7 @@ class WithdrawalUserEntity(
     encryptedNickname: String,
     encryptedMobile: String,
     encryptedRole: String,
-) {
-    @Id
-    @TimeBasedUuidStrategy
-    @Column(name = "id", columnDefinition = "VARCHAR(128)", nullable = false, updatable = false)
-    @Comment("식별키")
-    val id: String? = null
-
+) : TimeBasedPrimaryKey() {
     @Column(
         name = "login_id",
         columnDefinition = "VARCHAR(32)",

--- a/adapter-module/src/main/kotlin/com/reservation/persistence/withdrawal/repository/adapter/LoadResignTargetUserAdapter.kt
+++ b/adapter-module/src/main/kotlin/com/reservation/persistence/withdrawal/repository/adapter/LoadResignTargetUserAdapter.kt
@@ -13,7 +13,7 @@ class LoadResignTargetUserAdapter(
         return jpaRepository.findById(id)
             .map {
                 LoadResignTargetResult(
-                    it.id!!,
+                    it.identifier!!,
                     it.loginId,
                     it.password,
                     it.oldPassword,

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -254,11 +254,13 @@ project(":adapter-module") {
 
 
 
+
     tasks.named("bootJar") { enabled = true }
     tasks.named("jar") { enabled = false }
 
     val developmentOnly by configurations
     val kapt by configurations
+
 
     dependencies {
         implementation("org.springframework.boot:spring-boot-starter-actuator")


### PR DESCRIPTION
## 🎫 Context

- github:
- jira:

## 📄 Summary
- kt환경에서 custom id 전략 변경
- docs 작성

## ✨ What’s Changed
- 기존 entity에 지정한 필드를 MappedSuperClass로 추출하여 구현

## 🧩 Motivation & Background
- CustomKey 전략의 kt+JPA 의 궁합이 맞지 않음

## 🔥 Impact
- TimebasedUUID annotation 사용이 아닌 TimeBasedPrimaryKey super class 사용

## 🚦 How to Test (검증방법)
- x

## 📝 Notes

- 참고 문헌: [스포카에서 Kotlin으로 JPA Entity를 정의하는 방법](https://spoqa.github.io/2022/08/16/kotlin-jpa-entity.html)