### PR TITLE
chore: Redis Sentinel 포함된 Docker Compose 및 설정 추가

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -204,6 +204,18 @@ mysql_data
 .obsidian
 # End of https://www.toptal.com/developers/gitignore/api/kotlin,intellij,macos,gradle
 
+# Redis 데이터 (디렉토리 전체)
+redis/master-data/
+redis/replica1-data/
+redis/replica2-data/
+redis/sentinel-1/
+redis/sentinel-2/
+redis/sentinel-3/
+
+# 설정 파일만 유지하려면
+!redis/sentinel-1/sentinel.conf
+!redis/sentinel-2/sentinel.conf
+!redis/sentinel-3/sentinel.conf
 
 .kotlin
 .gemini

--- a/adapter-module/src/main/resources/docker/temporary.yaml
+++ b/adapter-module/src/main/resources/docker/temporary.yaml
@@ -4,4 +4,4 @@ spring:
   docker:
     compose:
       enabled: true
-      lifecycle-management: start_only
+      lifecycle-management: start_and_stop

--- a/adapter-module/src/main/resources/redis/datasource/temporary.yaml
+++ b/adapter-module/src/main/resources/redis/datasource/temporary.yaml
@@ -7,4 +7,14 @@ spring:
             host: localhost
             port: 6379
             timeout: 5000ms
+#    data:
+#        redis:
+#            sentinel:
+#                master: main-redis
+#                nodes:
+#                    - localhost:26379
+#                    - localhost:26380
+#                    - localhost:26381
+#            connect-timeout: 3000ms
+#            timeout: 50000ms
 

--- a/compose-sentinel.yaml
+++ b/compose-sentinel.yaml
@@ -1,0 +1,115 @@
+services:
+  mysql:
+    container_name: mysql-master
+    image: 'mysql:latest'
+    environment:
+      - 'MYSQL_DATABASE=prototype_reservation'
+      - 'MYSQL_ROOT_PASSWORD=verysecret'
+    ports:
+      - "3306:3306"
+    volumes:
+      - ./mysql_data:/var/lib/mysql
+      - ./docker-entrypoint-initdb.d/init.sql:/docker-entrypoint-initdb.d/init.sql:ro
+    healthcheck:
+      test: ["CMD", "mysqladmin", "ping", "-h", "localhost", "-u", "root", "-pverysecret"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+  redis-master:
+    container_name: redis-master
+    command: redis-server --appendonly yes
+    image: 'redis:latest'
+    ports:
+      - "6379:6379"
+    volumes:
+      - ./redis/master-data:/data
+    networks:
+      - redis-network
+    healthcheck:
+      test: [ "CMD", "redis-cli", "ping" ]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+  redis-replica-1:
+    container_name: redis-replica-1
+    command: redis-server --appendonly yes --replicaof redis-master 6379
+    image: 'redis:latest'
+    depends_on:
+      - redis-master
+    ports:
+      - "6380:6379"
+    volumes:
+      - ./redis/replica1-data:/data
+    networks:
+      - redis-network
+    healthcheck:
+      test: [ "CMD", "redis-cli", "ping" ]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+  redis-replica-2:
+    container_name: redis-replica-2
+    command: redis-server --appendonly yes --replicaof redis-master 6379
+    image: 'redis:latest'
+    depends_on:
+      - redis-master
+    ports:
+      - "6381:6379"
+    volumes:
+      - ./redis/replica2-data:/data
+    networks:
+      - redis-network
+    healthcheck:
+      test: [ "CMD", "redis-cli", "ping" ]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+
+  sentinel-1:
+    image: redis:latest
+    container_name: sentinel-1
+    command: redis-sentinel /etc/redis/sentinel.conf
+    ports:
+      - "26379:26379"
+    volumes:
+      - ./redis/sentinel/sentinel-1.conf:/etc/redis/sentinel.conf
+      - ./redis/sentinel/data-1:/data
+    depends_on:
+      redis-master:
+        condition: service_healthy
+    networks:
+      - redis-network
+
+  sentinel-2:
+    image: redis:latest
+    container_name: sentinel-2
+    command: redis-sentinel /etc/redis/sentinel.conf
+    ports:
+      - "26380:26379"
+    volumes:
+      - ./redis/sentinel/sentinel-2.conf:/etc/redis/sentinel.conf
+      - ./redis/sentinel/data-2:/data
+    depends_on:
+      redis-master:
+        condition: service_healthy
+    networks:
+      - redis-network
+
+  sentinel-3:
+    image: redis:latest
+    container_name: sentinel-3
+    command: redis-sentinel /etc/redis/sentinel.conf
+    ports:
+      - "26381:26379"
+    volumes:
+      - ./redis/sentinel/sentinel-3.conf:/etc/redis/sentinel.conf
+      - ./redis/sentinel/data-3:/data
+    depends_on:
+      redis-master:
+        condition: service_healthy
+    networks:
+      - redis-network
+
+networks:
+  redis-network:
+    driver: bridge

--- a/redis/sentinel/sentinel-1.conf
+++ b/redis/sentinel/sentinel-1.conf
@@ -1,0 +1,7 @@
+port 26379
+sentinel resolve-hostnames yes
+sentinel announce-hostnames yes
+sentinel monitor main-redis redis-master 6379 2
+sentinel down-after-milliseconds main-redis 5000
+sentinel parallel-syncs main-redis 1
+sentinel failover-timeout main-redis 10000

--- a/redis/sentinel/sentinel-2.conf
+++ b/redis/sentinel/sentinel-2.conf
@@ -1,0 +1,7 @@
+port 26379
+sentinel resolve-hostnames yes
+sentinel announce-hostnames yes
+sentinel monitor main-redis redis-master 6379 2
+sentinel down-after-milliseconds main-redis 5000
+sentinel parallel-syncs main-redis 1
+sentinel failover-timeout main-redis 10000

--- a/redis/sentinel/sentinel-3.conf
+++ b/redis/sentinel/sentinel-3.conf
@@ -1,0 +1,7 @@
+port 26379
+sentinel resolve-hostnames yes
+sentinel announce-hostnames yes
+sentinel monitor main-redis redis-master 6379 2
+sentinel down-after-milliseconds main-redis 5000
+sentinel parallel-syncs main-redis 1
+sentinel failover-timeout main-redis 10000


### PR DESCRIPTION


## 🎫 Context

- github:
- jira:

## 📄 Summary
- ~한 작업 진행

## ✨ What’s Changed
- .gitignore
  - Redis 관련 데이터 디렉토리(redis/master-data/, replica1/2, sentinel-*/ 등)를 무시하도록 추가
  - sentinel 설정 파일(sentinel.conf)만 예외로 허용하도록 설정

- compose-sentinel.yaml
  - MySQL, Redis 마스터, Redis 레플리카(2개), Redis Sentinel(3개) 서비스 정의 추가
  - 각 서비스의 포트, 볼륨, healthcheck, 네트워크 설정 포함
  - Redis 마스터-레플리카 구성과 Sentinel을 통한 장애 조치(failover) 환경 구성
  - redis-network 브리지 네트워크 정의 추가

- redis/sentinel/*.conf
  - sentinel-1/2/3 각 인스턴스용 Sentinel 설정 파일 추가
  - master 모니터링(main-redis -> redis-master:6379) 및 failover 관련 파라미터 설정

- adapter-module/src/main/resources/docker/temporary.yaml
  - Docker Compose lifecycle 관리 설정을 start_only에서 start_and_stop으로 변경

- adapter-module/src/main/resources/redis/datasource/temporary.yaml
  - 기존 단일 Redis 설정은 유지하되(포트 6379)
  - Sentinel 사용을 위한 예시 설정(주(master) 이름과 노드 목록)을 주석으로 추가하여 참조 가능하도록 함

## 🧩 Motivation & Background
- sentinel 구성

## 🔥 Impact
- sentinel 구성이 추가 됨

## 🚦 How to Test (검증방법)
- x

## 📝 Notes

- x