### PR TITLE
refactor/테스트 코드 정리 및 Mock 초기화 통합 [NO_REVIEW]

### DIFF
--- a/adapter-module/src/test/kotlin/com/reservation/config/security/TestSecurity.kt
+++ b/adapter-module/src/test/kotlin/com/reservation/config/security/TestSecurity.kt
@@ -12,6 +12,7 @@ import org.springframework.test.context.ActiveProfiles
 @ActiveProfiles(value = ["test"])
 @TestConfiguration
 @EnableWebSecurity
+@Deprecated("Test method has been changed")
 class TestSecurity {
     private val log = LoggerFactory.getLogger(this::class.java.simpleName)
 

--- a/adapter-module/src/test/kotlin/com/reservation/rest/category/cuisine/FindCuisineControllerTest.kt
+++ b/adapter-module/src/test/kotlin/com/reservation/rest/category/cuisine/FindCuisineControllerTest.kt
@@ -1,47 +1,44 @@
 package com.reservation.rest.category.cuisine
 
 import com.navercorp.fixturemonkey.kotlin.giveMe
-import com.ninjasquad.springmockk.MockkBean
 import com.reservation.category.cuisine.port.input.FindCuisinesByTitleUseCase
+import com.reservation.config.MockMvcFactory
+import com.reservation.config.SpringRestDocsKotestExtension
 import com.reservation.config.restdoc.Body
 import com.reservation.config.restdoc.Query
 import com.reservation.config.restdoc.RestDocuments
-import com.reservation.config.security.TestSecurity
 import com.reservation.fixture.CommonlyUsedArbitraries
 import com.reservation.fixture.FixtureMonkeyFactory
 import com.reservation.rest.category.CategoryUrl
 import io.kotest.core.spec.style.FunSpec
-import io.kotest.extensions.spring.SpringExtension
 import io.mockk.every
-import org.junit.jupiter.api.extension.ExtendWith
-import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDocs
-import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest
-import org.springframework.context.annotation.Import
+import io.mockk.mockk
 import org.springframework.http.HttpHeaders
-import org.springframework.restdocs.RestDocumentationExtension
 import org.springframework.restdocs.payload.JsonFieldType.NUMBER
 import org.springframework.restdocs.payload.JsonFieldType.STRING
-import org.springframework.test.context.ActiveProfiles
 import org.springframework.test.web.servlet.MockMvc
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
 import org.springframework.test.web.servlet.result.MockMvcResultHandlers.print
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
 
-@AutoConfigureRestDocs
-@ActiveProfiles(value = ["test"])
-@Import(value = [TestSecurity::class])
-@WebMvcTest(FindCuisineController::class)
-@ExtendWith(RestDocumentationExtension::class)
-class FindCuisineControllerTest(
-    private val mockMvc: MockMvc,
-) : FunSpec() {
-    override fun extensions() = listOf(SpringExtension)
+class FindCuisineControllerTest : FunSpec(
+    {
+        val restDocsExtension = SpringRestDocsKotestExtension()
+        extension(restDocsExtension)
 
-    @MockkBean
-    private lateinit var findCuisinesByTitleUseCase: FindCuisinesByTitleUseCase
+        lateinit var mockMvc: MockMvc
+        lateinit var findCuisinesByTitleUseCase: FindCuisinesByTitleUseCase
 
-    init {
+        beforeTest { testCase ->
+            findCuisinesByTitleUseCase = mockk<FindCuisinesByTitleUseCase>()
+            val controller = FindCuisineController(findCuisinesByTitleUseCase)
+            mockMvc =
+                MockMvcFactory.buildMockMvc(
+                    controller,
+                    restDocsExtension.restDocumentation(testCase),
+                )
+        }
 
         test("음식 카테고리를를 조회하여 총 16건의 결과가 노출된다.") {
             val pureMonkey = FixtureMonkeyFactory.giveMePureMonkey().build()
@@ -85,5 +82,5 @@ class FindCuisineControllerTest(
                         .create(),
                 )
         }
-    }
-}
+    },
+)

--- a/adapter-module/src/test/kotlin/com/reservation/rest/category/nationality/FindNationalitiesControllerTest.kt
+++ b/adapter-module/src/test/kotlin/com/reservation/rest/category/nationality/FindNationalitiesControllerTest.kt
@@ -1,48 +1,44 @@
 package com.reservation.rest.category.nationality
 
 import com.navercorp.fixturemonkey.kotlin.giveMe
-import com.ninjasquad.springmockk.MockkBean
 import com.reservation.category.nationality.port.input.FindNationalitiesByTitleUseCase
+import com.reservation.config.MockMvcFactory
+import com.reservation.config.SpringRestDocsKotestExtension
 import com.reservation.config.restdoc.Body
 import com.reservation.config.restdoc.Query
 import com.reservation.config.restdoc.RestDocuments
-import com.reservation.config.security.TestSecurity
 import com.reservation.fixture.CommonlyUsedArbitraries
 import com.reservation.fixture.FixtureMonkeyFactory
 import com.reservation.rest.category.CategoryUrl
 import com.reservation.rest.category.nationalities.FindNationalitiesController
 import io.kotest.core.spec.style.FunSpec
-import io.kotest.extensions.spring.SpringExtension
 import io.mockk.every
-import org.junit.jupiter.api.extension.ExtendWith
-import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDocs
-import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest
-import org.springframework.context.annotation.Import
+import io.mockk.mockk
 import org.springframework.http.HttpHeaders
-import org.springframework.restdocs.RestDocumentationExtension
 import org.springframework.restdocs.payload.JsonFieldType.NUMBER
 import org.springframework.restdocs.payload.JsonFieldType.STRING
-import org.springframework.test.context.ActiveProfiles
 import org.springframework.test.web.servlet.MockMvc
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
 import org.springframework.test.web.servlet.result.MockMvcResultHandlers.print
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
 
-@AutoConfigureRestDocs
-@ActiveProfiles(value = ["test"])
-@Import(value = [TestSecurity::class])
-@WebMvcTest(FindNationalitiesController::class)
-@ExtendWith(RestDocumentationExtension::class)
-class FindNationalitiesControllerTest(
-    private val mockMvc: MockMvc,
-) : FunSpec() {
-    override fun extensions() = listOf(SpringExtension)
+class FindNationalitiesControllerTest : FunSpec(
+    {
+        val restDocsExtension = SpringRestDocsKotestExtension()
+        extension(restDocsExtension)
 
-    @MockkBean
-    private lateinit var findNationalitiesByTitleUseCase: FindNationalitiesByTitleUseCase
-
-    init {
+        lateinit var mockMvc: MockMvc
+        lateinit var findNationalitiesByTitleUseCase: FindNationalitiesByTitleUseCase
+        beforeTest { testCase ->
+            findNationalitiesByTitleUseCase = mockk<FindNationalitiesByTitleUseCase>()
+            val controller = FindNationalitiesController(findNationalitiesByTitleUseCase)
+            mockMvc =
+                MockMvcFactory.buildMockMvc(
+                    controller,
+                    restDocsExtension.restDocumentation(testCase),
+                )
+        }
 
         test("국가 카테고리를를 조회하여 총 18건의 결과가 노출된다.") {
             val pureMonkey = FixtureMonkeyFactory.giveMePureMonkey().build()
@@ -86,5 +82,5 @@ class FindNationalitiesControllerTest(
                         .create(),
                 )
         }
-    }
-}
+    },
+)

--- a/adapter-module/src/test/kotlin/com/reservation/rest/category/tag/FindTagsControllerTest.kt
+++ b/adapter-module/src/test/kotlin/com/reservation/rest/category/tag/FindTagsControllerTest.kt
@@ -1,48 +1,45 @@
 package com.reservation.rest.category.tag
 
 import com.navercorp.fixturemonkey.kotlin.giveMe
-import com.ninjasquad.springmockk.MockkBean
 import com.reservation.category.tag.port.input.FindTagsByTitleUseCase
+import com.reservation.config.MockMvcFactory
+import com.reservation.config.SpringRestDocsKotestExtension
 import com.reservation.config.restdoc.Body
 import com.reservation.config.restdoc.Query
 import com.reservation.config.restdoc.RestDocuments
-import com.reservation.config.security.TestSecurity
 import com.reservation.fixture.CommonlyUsedArbitraries
 import com.reservation.fixture.FixtureMonkeyFactory
 import com.reservation.rest.category.CategoryUrl
 import com.reservation.rest.category.tags.FindTagsController
 import io.kotest.core.spec.style.FunSpec
-import io.kotest.extensions.spring.SpringExtension
 import io.mockk.every
-import org.junit.jupiter.api.extension.ExtendWith
-import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDocs
-import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest
-import org.springframework.context.annotation.Import
+import io.mockk.mockk
 import org.springframework.http.HttpHeaders
-import org.springframework.restdocs.RestDocumentationExtension
 import org.springframework.restdocs.payload.JsonFieldType.NUMBER
 import org.springframework.restdocs.payload.JsonFieldType.STRING
-import org.springframework.test.context.ActiveProfiles
 import org.springframework.test.web.servlet.MockMvc
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
 import org.springframework.test.web.servlet.result.MockMvcResultHandlers.print
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
 
-@AutoConfigureRestDocs
-@ActiveProfiles(value = ["test"])
-@Import(value = [TestSecurity::class])
-@WebMvcTest(FindTagsController::class)
-@ExtendWith(RestDocumentationExtension::class)
-class FindTagsControllerTest(
-    private val mockMvc: MockMvc,
-) : FunSpec() {
-    override fun extensions() = listOf(SpringExtension)
+class FindTagsControllerTest : FunSpec(
+    {
+        val restDocsExtension = SpringRestDocsKotestExtension()
+        extension(restDocsExtension)
 
-    @MockkBean
-    private lateinit var findNationalitiesQuery: FindTagsByTitleUseCase
+        lateinit var mockMvc: MockMvc
+        lateinit var findNationalitiesQuery: FindTagsByTitleUseCase
 
-    init {
+        beforeTest { testCase ->
+            findNationalitiesQuery = mockk<FindTagsByTitleUseCase>()
+            val controller = FindTagsController(findNationalitiesQuery)
+            mockMvc =
+                MockMvcFactory.buildMockMvc(
+                    controller,
+                    restDocsExtension.restDocumentation(testCase),
+                )
+        }
 
         test("태크 카테고리를를 조회하여 총 18건의 결과가 노출된다.") {
             val pureMonkey = FixtureMonkeyFactory.giveMePureMonkey().build()
@@ -86,5 +83,5 @@ class FindTagsControllerTest(
                         .create(),
                 )
         }
-    }
-}
+    },
+)

--- a/adapter-module/src/test/kotlin/com/reservation/rest/company/FindCompaniesControllerTest.kt
+++ b/adapter-module/src/test/kotlin/com/reservation/rest/company/FindCompaniesControllerTest.kt
@@ -1,48 +1,47 @@
 package com.reservation.rest.company
 
 import com.navercorp.fixturemonkey.kotlin.giveMe
-import com.ninjasquad.springmockk.MockkBean
 import com.reservation.company.port.input.FindCompaniesByCompanyNameUseCase
 import com.reservation.company.port.input.query.response.FindCompaniesQueryResult
+import com.reservation.config.MockMvcFactory
+import com.reservation.config.SpringRestDocsKotestExtension
 import com.reservation.config.restdoc.Body
 import com.reservation.config.restdoc.Query
 import com.reservation.config.restdoc.RestDocuments
-import com.reservation.config.security.TestSecurity
 import com.reservation.fixture.CommonlyUsedArbitraries
 import com.reservation.fixture.FixtureMonkeyFactory
 import com.reservation.rest.company.self.FindCompaniesController
 import io.kotest.core.spec.style.FunSpec
-import io.kotest.extensions.spring.SpringExtension
 import io.mockk.every
+import io.mockk.mockk
 import net.jqwik.api.Arbitraries
-import org.junit.jupiter.api.extension.ExtendWith
-import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDocs
-import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest
-import org.springframework.context.annotation.Import
 import org.springframework.http.HttpHeaders
-import org.springframework.restdocs.RestDocumentationExtension
 import org.springframework.restdocs.payload.JsonFieldType.STRING
-import org.springframework.test.context.ActiveProfiles
 import org.springframework.test.web.servlet.MockMvc
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
 import org.springframework.test.web.servlet.result.MockMvcResultHandlers.print
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
 
-@AutoConfigureRestDocs
-@ActiveProfiles(value = ["test"])
-@Import(value = [TestSecurity::class])
-@WebMvcTest(FindCompaniesController::class)
-@ExtendWith(RestDocumentationExtension::class)
-class FindCompaniesControllerTest(
-    private val mockMvc: MockMvc,
-) : FunSpec() {
-    override fun extensions() = listOf(SpringExtension)
+class FindCompaniesControllerTest : FunSpec(
+    {
 
-    @MockkBean
-    private lateinit var findCompaniesByCompanyNameUseCase: FindCompaniesByCompanyNameUseCase
+        val restDocsExtension = SpringRestDocsKotestExtension()
+        extension(restDocsExtension)
 
-    init {
+        lateinit var mockMvc: MockMvc
+        lateinit var findCompaniesByCompanyNameUseCase: FindCompaniesByCompanyNameUseCase
+
+        beforeTest { testCase ->
+            findCompaniesByCompanyNameUseCase = mockk<FindCompaniesByCompanyNameUseCase>()
+            val controller = FindCompaniesController(findCompaniesByCompanyNameUseCase)
+            mockMvc =
+                MockMvcFactory.buildMockMvc(
+                    controller,
+                    restDocsExtension.restDocumentation(testCase),
+                )
+        }
+
         test("회사를 조회하고 총 55건의 결과를 반환받는다.") {
 
             val pureMonkey = FixtureMonkeyFactory.giveMePureMonkey().build()
@@ -111,5 +110,5 @@ class FindCompaniesControllerTest(
                         .create(),
                 )
         }
-    }
-}
+    },
+)

--- a/adapter-module/src/test/kotlin/com/reservation/rest/resign/ResignUserControllerTest.kt
+++ b/adapter-module/src/test/kotlin/com/reservation/rest/resign/ResignUserControllerTest.kt
@@ -1,48 +1,44 @@
 package com.reservation.rest.resign
 
-import com.fasterxml.jackson.databind.ObjectMapper
-import com.ninjasquad.springmockk.MockkBean
+import com.reservation.config.MockMvcFactory
+import com.reservation.config.SpringRestDocsKotestExtension
 import com.reservation.config.restdoc.Body
 import com.reservation.config.restdoc.PathParameter
 import com.reservation.config.restdoc.RestDocuments
-import com.reservation.config.security.TestSecurity
 import com.reservation.fixture.CommonlyUsedArbitraries
 import com.reservation.rest.resign.remove.ResignUserController
 import com.reservation.user.resign.port.input.ResignUserUseCase
 import com.reservation.utilities.generator.uuid.UuidGenerator
 import io.kotest.core.spec.style.FunSpec
-import io.kotest.extensions.spring.SpringExtension
 import io.mockk.every
+import io.mockk.mockk
 import org.hamcrest.Matchers.equalTo
-import org.junit.jupiter.api.extension.ExtendWith
-import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDocs
-import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest
-import org.springframework.context.annotation.Import
 import org.springframework.http.HttpHeaders
-import org.springframework.restdocs.RestDocumentationExtension
 import org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.delete
 import org.springframework.restdocs.payload.JsonFieldType
-import org.springframework.test.context.ActiveProfiles
 import org.springframework.test.web.servlet.MockMvc
 import org.springframework.test.web.servlet.result.MockMvcResultHandlers.print
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
 
-@AutoConfigureRestDocs
-@ActiveProfiles(value = ["test"])
-@Import(value = [TestSecurity::class])
-@WebMvcTest(ResignUserController::class)
-@ExtendWith(RestDocumentationExtension::class)
-class ResignUserControllerTest(
-    private val mockMvc: MockMvc,
-    private val objectMapper: ObjectMapper,
-) : FunSpec() {
-    override fun extensions() = listOf(SpringExtension)
+class ResignUserControllerTest : FunSpec(
+    {
 
-    @MockkBean
-    private lateinit var resignUserUseCase: ResignUserUseCase
+        val restDocsExtension = SpringRestDocsKotestExtension()
+        extension(restDocsExtension)
 
-    init {
+        lateinit var mockMvc: MockMvc
+        lateinit var resignUserUseCase: ResignUserUseCase
+
+        beforeTest { testCase ->
+            resignUserUseCase = mockk<ResignUserUseCase>()
+            val controller = ResignUserController(resignUserUseCase)
+            mockMvc =
+                MockMvcFactory.buildMockMvc(
+                    controller,
+                    restDocsExtension.restDocumentation(testCase),
+                )
+        }
 
         test("사용자가 탈퇴한다.") {
 
@@ -92,5 +88,5 @@ class ResignUserControllerTest(
                         .create(),
                 )
         }
-    }
-}
+    },
+)

--- a/adapter-module/src/test/kotlin/com/reservation/rest/schedule/holiday/CreateHolidayControllerTest.kt
+++ b/adapter-module/src/test/kotlin/com/reservation/rest/schedule/holiday/CreateHolidayControllerTest.kt
@@ -3,6 +3,7 @@ package com.reservation.rest.schedule.holiday
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.databind.SerializationFeature
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
+import com.fasterxml.jackson.module.kotlin.KotlinModule
 import com.navercorp.fixturemonkey.kotlin.giveMeBuilder
 import com.reservation.config.MockMvcFactory
 import com.reservation.config.SpringRestDocsKotestExtension
@@ -53,6 +54,7 @@ class CreateHolidayControllerTest : FunSpec(
         val objectMapper =
             ObjectMapper()
                 .registerModule(JavaTimeModule())
+                .registerModules(KotlinModule.Builder().build())
                 .disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS)
 
         fun perfectCase() =

--- a/adapter-module/src/test/kotlin/com/reservation/rest/timetable/find/FindTimeTableControllerTest.kt
+++ b/adapter-module/src/test/kotlin/com/reservation/rest/timetable/find/FindTimeTableControllerTest.kt
@@ -1,8 +1,5 @@
 package com.reservation.rest.timetable.find
 
-import com.fasterxml.jackson.databind.ObjectMapper
-import com.fasterxml.jackson.databind.SerializationFeature
-import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
 import com.navercorp.fixturemonkey.kotlin.giveMe
 import com.reservation.config.MockMvcFactory
 import com.reservation.config.SpringRestDocsKotestExtension
@@ -11,7 +8,6 @@ import com.reservation.config.restdoc.Query
 import com.reservation.config.restdoc.RestDocuments
 import com.reservation.fixture.CommonlyUsedArbitraries
 import com.reservation.fixture.FixtureMonkeyFactory
-import com.reservation.rest.schedule.timespan.TimeSpanUrl
 import com.reservation.rest.timetable.FindTimeTableController
 import com.reservation.rest.timetable.TimeTableUrl
 import com.reservation.timetable.port.input.FindTimeTableUseCase
@@ -42,11 +38,6 @@ class FindTimeTableControllerTest : FunSpec(
 
         val dateTimeFormat = DateTimeFormatter.ISO_DATE
         val pureMonkey = FixtureMonkeyFactory.giveMePureMonkey().build()
-        var url = TimeSpanUrl.CREATE
-        val objectMapper =
-            ObjectMapper()
-                .registerModule(JavaTimeModule())
-                .disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS)
 
         beforeTest { testCase ->
             findTimeTableUseCase = mockk<FindTimeTableUseCase>()

--- a/adapter-module/src/test/kotlin/com/reservation/rest/user/general/attribute/GeneralUserChangeNicknameControllerTest.kt
+++ b/adapter-module/src/test/kotlin/com/reservation/rest/user/general/attribute/GeneralUserChangeNicknameControllerTest.kt
@@ -1,50 +1,55 @@
 package com.reservation.rest.user.general.attribute
 
 import com.fasterxml.jackson.databind.ObjectMapper
-import com.ninjasquad.springmockk.MockkBean
+import com.fasterxml.jackson.databind.SerializationFeature
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
+import com.fasterxml.jackson.module.kotlin.KotlinModule
+import com.reservation.config.MockMvcFactory
+import com.reservation.config.SpringRestDocsKotestExtension
 import com.reservation.config.restdoc.Body
 import com.reservation.config.restdoc.PathParameter
 import com.reservation.config.restdoc.RestDocuments
-import com.reservation.config.security.TestSecurity
 import com.reservation.fixture.CommonlyUsedArbitraries
 import com.reservation.rest.user.general.attribute.change.nickname.GeneralUserChangeNicknameController
 import com.reservation.rest.user.general.request.GeneralUserChangeNicknameRequest
 import com.reservation.user.self.port.input.ChangeGeneralUserNicknameUseCase
 import com.reservation.utilities.generator.uuid.UuidGenerator
 import io.kotest.core.spec.style.FunSpec
-import io.kotest.extensions.spring.SpringExtension
 import io.mockk.every
+import io.mockk.mockk
 import org.hamcrest.Matchers.equalTo
-import org.junit.jupiter.api.extension.ExtendWith
-import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDocs
-import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest
-import org.springframework.context.annotation.Import
 import org.springframework.http.HttpHeaders
 import org.springframework.http.MediaType
-import org.springframework.restdocs.RestDocumentationExtension
 import org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.patch
 import org.springframework.restdocs.payload.JsonFieldType
-import org.springframework.test.context.ActiveProfiles
 import org.springframework.test.web.servlet.MockMvc
 import org.springframework.test.web.servlet.result.MockMvcResultHandlers.print
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
 
-@AutoConfigureRestDocs
-@ActiveProfiles(value = ["test"])
-@Import(value = [TestSecurity::class])
-@WebMvcTest(GeneralUserChangeNicknameController::class)
-@ExtendWith(RestDocumentationExtension::class)
-class GeneralUserChangeNicknameControllerTest(
-    private val mockMvc: MockMvc,
-    private val objectMapper: ObjectMapper,
-) : FunSpec() {
-    override fun extensions() = listOf(SpringExtension)
+class GeneralUserChangeNicknameControllerTest : FunSpec(
+    {
+        val restDocsExtension = SpringRestDocsKotestExtension()
+        extension(restDocsExtension)
 
-    @MockkBean
-    private lateinit var changeGeneralUserNicknameUseCase: ChangeGeneralUserNicknameUseCase
+        lateinit var mockMvc: MockMvc
+        lateinit var changeGeneralUserNicknameUseCase: ChangeGeneralUserNicknameUseCase
 
-    init {
+        beforeTest { testCase ->
+            changeGeneralUserNicknameUseCase = mockk<ChangeGeneralUserNicknameUseCase>()
+            val controller = GeneralUserChangeNicknameController(changeGeneralUserNicknameUseCase)
+            mockMvc =
+                MockMvcFactory.buildMockMvc(
+                    controller,
+                    restDocsExtension.restDocumentation(testCase),
+                )
+        }
+
+        val objectMapper =
+            ObjectMapper()
+                .registerModule(JavaTimeModule())
+                .registerModules(KotlinModule.Builder().build())
+                .disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS)
 
         test("닉네임 변경 조건에 부합하여 닉네임이 변경된다.") {
             val url = "/api/v1/user/{id}/nickname"
@@ -109,5 +114,5 @@ class GeneralUserChangeNicknameControllerTest(
                         .create(),
                 )
         }
-    }
-}
+    },
+)

--- a/adapter-module/src/test/kotlin/com/reservation/rest/user/general/find/id/FindGeneralUserIdsControllerTest.kt
+++ b/adapter-module/src/test/kotlin/com/reservation/rest/user/general/find/id/FindGeneralUserIdsControllerTest.kt
@@ -1,12 +1,11 @@
 package com.reservation.rest.user.general.find.id
 
-import com.fasterxml.jackson.databind.ObjectMapper
 import com.navercorp.fixturemonkey.kotlin.giveMeBuilder
-import com.ninjasquad.springmockk.MockkBean
+import com.reservation.config.MockMvcFactory
+import com.reservation.config.SpringRestDocsKotestExtension
 import com.reservation.config.restdoc.Body
 import com.reservation.config.restdoc.Query
 import com.reservation.config.restdoc.RestDocuments
-import com.reservation.config.security.TestSecurity
 import com.reservation.fixture.CommonlyUsedArbitraries
 import com.reservation.fixture.FixtureMonkeyFactory
 import com.reservation.rest.user.general.GeneralUserUrl
@@ -14,37 +13,33 @@ import com.reservation.rest.user.general.sign.find.id.FindGeneralUserIdsControll
 import com.reservation.user.self.port.input.FindGeneralUserIdsUseCase
 import com.reservation.user.self.port.input.query.response.FindGeneralUserIdQueryResult
 import io.kotest.core.spec.style.FunSpec
-import io.kotest.extensions.spring.SpringExtension
 import io.mockk.every
-import org.junit.jupiter.api.extension.ExtendWith
-import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDocs
-import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest
-import org.springframework.context.annotation.Import
+import io.mockk.mockk
 import org.springframework.http.HttpHeaders
-import org.springframework.restdocs.RestDocumentationExtension
 import org.springframework.restdocs.payload.JsonFieldType.STRING
-import org.springframework.test.context.ActiveProfiles
 import org.springframework.test.web.servlet.MockMvc
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
 import org.springframework.test.web.servlet.result.MockMvcResultHandlers.print
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
 
-@AutoConfigureRestDocs
-@ActiveProfiles(value = ["test"])
-@Import(value = [TestSecurity::class])
-@WebMvcTest(FindGeneralUserIdsController::class)
-@ExtendWith(RestDocumentationExtension::class)
-class FindGeneralUserIdsControllerTest(
-    private val mockMvc: MockMvc,
-    private val objectMapper: ObjectMapper,
-) : FunSpec() {
-    override fun extensions() = listOf(SpringExtension)
+class FindGeneralUserIdsControllerTest : FunSpec(
+    {
+        val restDocsExtension = SpringRestDocsKotestExtension()
+        extension(restDocsExtension)
 
-    @MockkBean
-    private lateinit var findGeneralUserIdsUseCase: FindGeneralUserIdsUseCase
+        lateinit var mockMvc: MockMvc
+        lateinit var findGeneralUserIdsUseCase: FindGeneralUserIdsUseCase
 
-    init {
+        beforeTest { testCase ->
+            findGeneralUserIdsUseCase = mockk<FindGeneralUserIdsUseCase>()
+            val controller = FindGeneralUserIdsController(findGeneralUserIdsUseCase)
+            mockMvc =
+                MockMvcFactory.buildMockMvc(
+                    controller,
+                    restDocsExtension.restDocumentation(testCase),
+                )
+        }
 
         test("올바르지 않은 이메일을 입력하여 아이디를 찾을 수 없다.") {
 
@@ -116,5 +111,5 @@ class FindGeneralUserIdsControllerTest(
                         .create(),
                 )
         }
-    }
-}
+    },
+)

--- a/adapter-module/src/test/kotlin/com/reservation/rest/user/general/find/password/FindGeneralUserPasswordControllerTest.kt
+++ b/adapter-module/src/test/kotlin/com/reservation/rest/user/general/find/password/FindGeneralUserPasswordControllerTest.kt
@@ -1,12 +1,15 @@
 package com.reservation.rest.user.general.find.password
 
 import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.databind.SerializationFeature
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
+import com.fasterxml.jackson.module.kotlin.KotlinModule
 import com.navercorp.fixturemonkey.kotlin.giveMeOne
-import com.ninjasquad.springmockk.MockkBean
 import com.reservation.common.exceptions.NoSuchPersistedElementException
+import com.reservation.config.MockMvcFactory
+import com.reservation.config.SpringRestDocsKotestExtension
 import com.reservation.config.restdoc.Body
 import com.reservation.config.restdoc.RestDocuments
-import com.reservation.config.security.TestSecurity
 import com.reservation.fixture.CommonlyUsedArbitraries
 import com.reservation.fixture.FixtureMonkeyFactory
 import com.reservation.rest.user.general.GeneralUserUrl
@@ -14,40 +17,42 @@ import com.reservation.rest.user.general.request.FindGeneralUserPasswordRequest
 import com.reservation.rest.user.general.sign.find.password.FindGeneralUserPasswordController
 import com.reservation.user.self.port.input.FindGeneralUserPasswordUseCase
 import io.kotest.core.spec.style.FunSpec
-import io.kotest.extensions.spring.SpringExtension
 import io.mockk.every
+import io.mockk.mockk
 import org.hamcrest.Matchers.equalTo
-import org.junit.jupiter.api.extension.ExtendWith
-import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDocs
-import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest
-import org.springframework.context.annotation.Import
 import org.springframework.http.HttpHeaders
 import org.springframework.http.MediaType
-import org.springframework.restdocs.RestDocumentationExtension
 import org.springframework.restdocs.payload.JsonFieldType.BOOLEAN
 import org.springframework.restdocs.payload.JsonFieldType.STRING
-import org.springframework.test.context.ActiveProfiles
 import org.springframework.test.web.servlet.MockMvc
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch
 import org.springframework.test.web.servlet.result.MockMvcResultHandlers.print
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
 
-@AutoConfigureRestDocs
-@ActiveProfiles(value = ["test"])
-@Import(value = [TestSecurity::class])
-@WebMvcTest(FindGeneralUserPasswordController::class)
-@ExtendWith(RestDocumentationExtension::class)
-class FindGeneralUserPasswordControllerTest(
-    private val mockMvc: MockMvc,
-    private val objectMapper: ObjectMapper,
-) : FunSpec() {
-    override fun extensions() = listOf(SpringExtension)
+class FindGeneralUserPasswordControllerTest : FunSpec(
+    {
+        val restDocsExtension = SpringRestDocsKotestExtension()
+        extension(restDocsExtension)
 
-    @MockkBean
-    private lateinit var findGeneralUserPasswordUseCase: FindGeneralUserPasswordUseCase
+        lateinit var mockMvc: MockMvc
+        lateinit var findGeneralUserPasswordUseCase: FindGeneralUserPasswordUseCase
 
-    init {
+        beforeTest { testCase ->
+            findGeneralUserPasswordUseCase = mockk<FindGeneralUserPasswordUseCase>()
+            val controller = FindGeneralUserPasswordController(findGeneralUserPasswordUseCase)
+            mockMvc =
+                MockMvcFactory.buildMockMvc(
+                    controller,
+                    restDocsExtension.restDocumentation(testCase),
+                )
+        }
+
+        val objectMapper =
+            ObjectMapper()
+                .registerModule(JavaTimeModule())
+                .registerModules(KotlinModule.Builder().build())
+                .disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS)
 
         test("올바르지 않은 아이디, 이메일을 입력하여 아이디를 찾을 수 없다.") {
             val pureMonkey = FixtureMonkeyFactory.giveMePureMonkey().build()
@@ -119,5 +124,5 @@ class FindGeneralUserPasswordControllerTest(
                         .create(),
                 )
         }
-    }
-}
+    },
+)

--- a/adapter-module/src/test/kotlin/com/reservation/rest/user/general/self/FindGeneralUserControllerTest.kt
+++ b/adapter-module/src/test/kotlin/com/reservation/rest/user/general/self/FindGeneralUserControllerTest.kt
@@ -1,13 +1,12 @@
 package com.reservation.rest.user.general.self
 
-import com.fasterxml.jackson.databind.ObjectMapper
 import com.navercorp.fixturemonkey.kotlin.giveMeBuilder
-import com.ninjasquad.springmockk.MockkBean
 import com.reservation.common.exceptions.NoSuchPersistedElementException
+import com.reservation.config.MockMvcFactory
+import com.reservation.config.SpringRestDocsKotestExtension
 import com.reservation.config.restdoc.Body
 import com.reservation.config.restdoc.PathParameter
 import com.reservation.config.restdoc.RestDocuments
-import com.reservation.config.security.TestSecurity
 import com.reservation.fixture.CommonlyUsedArbitraries
 import com.reservation.fixture.FixtureMonkeyFactory
 import com.reservation.rest.user.general.GeneralUserUrl
@@ -16,37 +15,34 @@ import com.reservation.user.self.port.input.FindGeneralUserUseCase
 import com.reservation.user.self.port.input.query.response.FindGeneralUserQueryResult
 import com.reservation.utilities.generator.uuid.UuidGenerator
 import io.kotest.core.spec.style.FunSpec
-import io.kotest.extensions.spring.SpringExtension
 import io.mockk.every
-import org.junit.jupiter.api.extension.ExtendWith
-import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDocs
-import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest
-import org.springframework.context.annotation.Import
+import io.mockk.mockk
 import org.springframework.http.HttpHeaders
-import org.springframework.restdocs.RestDocumentationExtension
 import org.springframework.restdocs.payload.JsonFieldType.STRING
-import org.springframework.test.context.ActiveProfiles
 import org.springframework.test.web.servlet.MockMvc
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
 import org.springframework.test.web.servlet.result.MockMvcResultHandlers.print
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
 
-@AutoConfigureRestDocs
-@ActiveProfiles(value = ["test"])
-@Import(value = [TestSecurity::class])
-@WebMvcTest(FindGeneralUserController::class)
-@ExtendWith(RestDocumentationExtension::class)
-class FindGeneralUserControllerTest(
-    private val mockMvc: MockMvc,
-    private val objectMapper: ObjectMapper,
-) : FunSpec() {
-    override fun extensions() = listOf(SpringExtension)
+class FindGeneralUserControllerTest : FunSpec(
+    {
+        val restDocsExtension = SpringRestDocsKotestExtension()
+        extension(restDocsExtension)
 
-    @MockkBean
-    private lateinit var findGeneralUserUseCase: FindGeneralUserUseCase
+        lateinit var mockMvc: MockMvc
+        lateinit var findGeneralUserUseCase: FindGeneralUserUseCase
 
-    init {
+        beforeTest { testCase ->
+            findGeneralUserUseCase = mockk<FindGeneralUserUseCase>()
+            val controller = FindGeneralUserController(findGeneralUserUseCase)
+            mockMvc =
+                MockMvcFactory.buildMockMvc(
+                    controller,
+                    restDocsExtension.restDocumentation(testCase),
+                )
+        }
+
         test("사용자를 찾을 수 없음") {
 
             val id = UuidGenerator.generate()
@@ -120,5 +116,5 @@ class FindGeneralUserControllerTest(
                         .create(),
                 )
         }
-    }
-}
+    },
+)

--- a/adapter-module/src/test/kotlin/com/reservation/rest/user/general/sign/GeneralUserSignOutControllerTest.kt
+++ b/adapter-module/src/test/kotlin/com/reservation/rest/user/general/sign/GeneralUserSignOutControllerTest.kt
@@ -1,22 +1,16 @@
 package com.reservation.rest.user.general.sign
 
+import com.reservation.config.MockMvcFactory
+import com.reservation.config.SpringRestDocsKotestExtension
 import com.reservation.config.restdoc.RestDocuments
-import com.reservation.config.security.TestSecurity
 import com.reservation.rest.user.RefreshTokenDefinitions
 import com.reservation.rest.user.general.GeneralUserUrl
 import com.reservation.rest.user.general.sign.outcome.GeneralUserSignOutController
 import io.kotest.core.spec.style.FunSpec
-import io.kotest.extensions.spring.SpringExtension
 import jakarta.servlet.http.Cookie
 import net.jqwik.api.Arbitraries
-import org.junit.jupiter.api.extension.ExtendWith
-import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDocs
-import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest
-import org.springframework.context.annotation.Import
 import org.springframework.http.HttpHeaders
-import org.springframework.restdocs.RestDocumentationExtension
 import org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.patch
-import org.springframework.test.context.ActiveProfiles
 import org.springframework.test.web.servlet.MockMvc
 import org.springframework.test.web.servlet.result.MockMvcResultHandlers.print
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.content
@@ -24,17 +18,22 @@ import org.springframework.test.web.servlet.result.MockMvcResultMatchers.cookie
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
 import java.util.Base64
 
-@AutoConfigureRestDocs
-@ActiveProfiles(value = ["test"])
-@Import(value = [TestSecurity::class])
-@WebMvcTest(GeneralUserSignOutController::class)
-@ExtendWith(RestDocumentationExtension::class)
-class GeneralUserSignOutControllerTest(
-    private val mockMvc: MockMvc,
-) : FunSpec() {
-    override fun extensions() = listOf(SpringExtension)
+class GeneralUserSignOutControllerTest : FunSpec(
+    {
+        val restDocsExtension = SpringRestDocsKotestExtension()
+        extension(restDocsExtension)
 
-    init {
+        lateinit var mockMvc: MockMvc
+
+        beforeTest { testCase ->
+            val controller = GeneralUserSignOutController()
+            mockMvc =
+                MockMvcFactory.buildMockMvc(
+                    controller,
+                    restDocsExtension.restDocumentation(testCase),
+                )
+        }
+
         val encoder = Base64.getEncoder()
         val accessToken =
             "Bearer ${
@@ -93,5 +92,5 @@ class GeneralUserSignOutControllerTest(
                         .create(),
                 )
         }
-    }
-}
+    },
+)

--- a/adapter-module/src/test/kotlin/com/reservation/rest/user/general/sign/RefreshGeneralUserControllerTest.kt
+++ b/adapter-module/src/test/kotlin/com/reservation/rest/user/general/sign/RefreshGeneralUserControllerTest.kt
@@ -1,10 +1,9 @@
 package com.reservation.rest.user.general.sign
 
-import com.fasterxml.jackson.databind.ObjectMapper
-import com.ninjasquad.springmockk.MockkBean
+import com.reservation.config.MockMvcFactory
+import com.reservation.config.SpringRestDocsKotestExtension
 import com.reservation.config.restdoc.Body
 import com.reservation.config.restdoc.RestDocuments
-import com.reservation.config.security.TestSecurity
 import com.reservation.exceptions.UnauthorizedException
 import com.reservation.fixture.CommonlyUsedArbitraries
 import com.reservation.rest.user.RefreshTokenDefinitions
@@ -13,36 +12,32 @@ import com.reservation.rest.user.general.sign.refresh.RefreshGeneralUserControll
 import com.reservation.user.self.port.input.RefreshGeneralUserAccessTokenUseCase
 import com.reservation.user.self.port.input.query.response.RefreshResult
 import io.kotest.core.spec.style.FunSpec
-import io.kotest.extensions.spring.SpringExtension
 import io.mockk.every
+import io.mockk.mockk
 import jakarta.servlet.http.Cookie
-import org.junit.jupiter.api.extension.ExtendWith
-import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDocs
-import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest
-import org.springframework.context.annotation.Import
-import org.springframework.restdocs.RestDocumentationExtension
 import org.springframework.restdocs.payload.JsonFieldType.STRING
-import org.springframework.test.context.ActiveProfiles
 import org.springframework.test.web.servlet.MockMvc
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
 import org.springframework.test.web.servlet.result.MockMvcResultHandlers.print
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
 
-@AutoConfigureRestDocs
-@ActiveProfiles(value = ["test"])
-@Import(value = [TestSecurity::class])
-@WebMvcTest(RefreshGeneralUserController::class)
-@ExtendWith(RestDocumentationExtension::class)
-class RefreshGeneralUserControllerTest(
-    private val mockMvc: MockMvc,
-    private val objectMapper: ObjectMapper,
-) : FunSpec() {
-    override fun extensions() = listOf(SpringExtension)
+class RefreshGeneralUserControllerTest : FunSpec(
+    {
+        val restDocsExtension = SpringRestDocsKotestExtension()
+        extension(restDocsExtension)
 
-    @MockkBean
-    private lateinit var refreshGeneralUserAccessTokenUseCase: RefreshGeneralUserAccessTokenUseCase
+        lateinit var mockMvc: MockMvc
+        lateinit var refreshGeneralUserAccessTokenUseCase: RefreshGeneralUserAccessTokenUseCase
 
-    init {
+        beforeTest { testCase ->
+            refreshGeneralUserAccessTokenUseCase = mockk<RefreshGeneralUserAccessTokenUseCase>()
+            val controller = RefreshGeneralUserController(refreshGeneralUserAccessTokenUseCase)
+            mockMvc =
+                MockMvcFactory.buildMockMvc(
+                    controller,
+                    restDocsExtension.restDocumentation(testCase),
+                )
+        }
 
         test("리프레시에 실패한다.") {
 
@@ -95,5 +90,5 @@ class RefreshGeneralUserControllerTest(
                         .create(),
                 )
         }
-    }
-}
+    },
+)

--- a/adapter-module/src/test/kotlin/com/reservation/rest/user/seller/sign/SellerUserSignOutControllerTest.kt
+++ b/adapter-module/src/test/kotlin/com/reservation/rest/user/seller/sign/SellerUserSignOutControllerTest.kt
@@ -1,7 +1,8 @@
 package com.reservation.rest.user.seller.sign
 
+import com.reservation.config.MockMvcFactory
+import com.reservation.config.SpringRestDocsKotestExtension
 import com.reservation.config.restdoc.RestDocuments
-import com.reservation.config.security.TestSecurity
 import com.reservation.rest.user.RefreshTokenDefinitions
 import com.reservation.rest.user.seller.SellerUserUrl
 import com.reservation.rest.user.seller.sign.outcome.SellerUserSignOutController
@@ -9,14 +10,8 @@ import io.kotest.core.spec.style.FunSpec
 import io.kotest.extensions.spring.SpringExtension
 import jakarta.servlet.http.Cookie
 import net.jqwik.api.Arbitraries
-import org.junit.jupiter.api.extension.ExtendWith
-import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDocs
-import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest
-import org.springframework.context.annotation.Import
 import org.springframework.http.HttpHeaders
-import org.springframework.restdocs.RestDocumentationExtension
 import org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.patch
-import org.springframework.test.context.ActiveProfiles
 import org.springframework.test.web.servlet.MockMvc
 import org.springframework.test.web.servlet.result.MockMvcResultHandlers.print
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.content
@@ -24,17 +19,25 @@ import org.springframework.test.web.servlet.result.MockMvcResultMatchers.cookie
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
 import java.util.Base64
 
-@AutoConfigureRestDocs
-@ActiveProfiles(value = ["test"])
-@Import(value = [TestSecurity::class])
-@WebMvcTest(SellerUserSignOutController::class)
-@ExtendWith(RestDocumentationExtension::class)
-class SellerUserSignOutControllerTest(
-    private val mockMvc: MockMvc,
-) : FunSpec() {
+class SellerUserSignOutControllerTest : FunSpec() {
     override fun extensions() = listOf(SpringExtension)
 
     init {
+
+        val restDocsExtension = SpringRestDocsKotestExtension()
+        extension(restDocsExtension)
+
+        lateinit var mockMvc: MockMvc
+
+        beforeTest { testCase ->
+            val controller = SellerUserSignOutController()
+            mockMvc =
+                MockMvcFactory.buildMockMvc(
+                    controller,
+                    restDocsExtension.restDocumentation(testCase),
+                )
+        }
+
         val encoder = Base64.getEncoder()
         val accessToken =
             "Bearer ${


### PR DESCRIPTION

## 🎫 Context

- github:
- jira:

## 📄 Summary
- ~한 작업 진행

## ✨ What’s Changed
- 사용하지 않는Mapper, JavaTime, SerializationFeature import 및 관련 변수 제거
  -SpanUrl 등 사용 않는 import 제거
  - 테스트 내부에서 불필요한 URL 변수 제거로 가독성 향상

- SellerUserSignOutControllerTest
  - 기존의 Spring 테스트 애노테이션(@WebMvcTest 등)과 확장 설정 제거
  - Kotest 기반으로 SpringRestDocsKotestExtension을 사용한 RestDocs 초기화 및 MockMvc 생성 로직 추가
  - MockMvcFactory를 이용해 테스트마다 컨트롤러와 RestDocs를 바인딩하도록 변경
  - 불필요한 TestSecurity 의존 제거 및 클래스 단순화

- TestSecurity
  - TestSecurity 설정에 Deprecated 애노테이션 추가 (테스트 방식 변경을 알림)

- CreateHolidayControllerTest
  - ObjectMapper에 KotlinModule 등록 추가 (Kotlin 직렬화/역직렬화 지원 보완)


## 🧩 Motivation & Background
- `@WebMvcTest` 제거를 통한 테스트 최적화

## 🔥 Impact
- `@WebMvcTest` 방법 변경

## 🚦 How to Test (검증방법)
- 수정으로 세팅하여 필요한 Bean만 생성하도록 변경

## 📝 Notes

- 