### PR TITLE
refactor: UserFieldMustNotBeNullException로 교체 및 테스트 수정 [NO_REVIEW]

### DIFF
--- a/application-module/src/main/kotlin/com/reservation/user/self/exceptions/UserFieldMustNotBeNullException.kt
+++ b/application-module/src/main/kotlin/com/reservation/user/self/exceptions/UserFieldMustNotBeNullException.kt
@@ -1,0 +1,7 @@
+package com.reservation.user.self.exceptions
+
+import com.reservation.exceptions.InvalidSituationException
+
+class UserFieldMustNotBeNullException(
+    message: String = "This field must not be null",
+) : InvalidSituationException(message)

--- a/application-module/src/main/kotlin/com/reservation/user/self/usecase/ChangeGeneralUserNicknameService.kt
+++ b/application-module/src/main/kotlin/com/reservation/user/self/usecase/ChangeGeneralUserNicknameService.kt
@@ -3,10 +3,10 @@ package com.reservation.user.self.usecase
 import com.reservation.common.exceptions.AlreadyPersistedException
 import com.reservation.common.exceptions.NoSuchPersistedElementException
 import com.reservation.config.annotations.UseCase
-import com.reservation.exceptions.InvalidSituationException
 import com.reservation.user.history.change.port.input.CreateGeneralUserChangeHistoryUseCase
 import com.reservation.user.history.change.port.input.command.request.CreateGeneralUserChangeHistoryCommand
 import com.reservation.user.self.User
+import com.reservation.user.self.exceptions.UserFieldMustNotBeNullException
 import com.reservation.user.self.port.input.ChangeGeneralUserNicknameUseCase
 import com.reservation.user.self.port.input.command.request.ChangeGeneralUserNicknameCommand
 import com.reservation.user.self.port.output.ChangeGeneralUserNickname
@@ -71,7 +71,7 @@ class ChangeGeneralUserNicknameService(
 
         return changeGeneralUserNickname.command(
             ChangeGeneralUserNicknameDto(
-                user.identifier ?: run { throw InvalidSituationException() },
+                user.identifier ?: run { throw UserFieldMustNotBeNullException() },
                 user.userNickname,
             ),
         )

--- a/application-module/src/main/kotlin/com/reservation/user/self/usecase/ChangeGeneralUserPasswordService.kt
+++ b/application-module/src/main/kotlin/com/reservation/user/self/usecase/ChangeGeneralUserPasswordService.kt
@@ -2,7 +2,7 @@ package com.reservation.user.self.usecase
 
 import com.reservation.common.exceptions.NoSuchPersistedElementException
 import com.reservation.config.annotations.UseCase
-import com.reservation.exceptions.InvalidSituationException
+import com.reservation.user.self.exceptions.UserFieldMustNotBeNullException
 import com.reservation.user.self.port.input.ChangeGeneralUserPasswordUseCase
 import com.reservation.user.self.port.input.command.request.ChangeGeneralUserPasswordCommand
 import com.reservation.user.self.port.output.ChangeGeneralUserPassword
@@ -29,10 +29,10 @@ class ChangeGeneralUserPasswordService(
 
         return changeGeneralUserPassword.command(
             ChangeGeneralUserPasswordInquiry(
-                user.identifier ?: run { throw InvalidSituationException() },
+                user.identifier ?: run { throw UserFieldMustNotBeNullException() },
                 user.userEncodedPassword,
-                user.userOldEncodedPassword ?: run { throw InvalidSituationException() },
-                user.userPasswordChangedDatetime ?: run { throw InvalidSituationException() },
+                user.userOldEncodedPassword ?: run { throw UserFieldMustNotBeNullException() },
+                user.userPasswordChangedDatetime ?: run { throw UserFieldMustNotBeNullException() },
             ),
         )
     }

--- a/application-module/src/main/kotlin/com/reservation/user/self/usecase/FindGeneralUserPasswordService.kt
+++ b/application-module/src/main/kotlin/com/reservation/user/self/usecase/FindGeneralUserPasswordService.kt
@@ -2,8 +2,8 @@ package com.reservation.user.self.usecase
 
 import com.reservation.common.exceptions.NoSuchPersistedElementException
 import com.reservation.config.annotations.UseCase
-import com.reservation.exceptions.InvalidSituationException
 import com.reservation.user.self.User
+import com.reservation.user.self.exceptions.UserFieldMustNotBeNullException
 import com.reservation.user.self.port.input.FindGeneralUserPasswordUseCase
 import com.reservation.user.self.port.input.query.request.FindGeneralUserPasswordCommand
 import com.reservation.user.self.port.output.LoadGeneralUserByLoginIdAndEmail
@@ -39,7 +39,7 @@ class FindGeneralUserPasswordService(
             user.userOldEncodedPassword == null ||
             user.userPasswordChangedDatetime == null
         ) {
-            throw InvalidSituationException()
+            throw UserFieldMustNotBeNullException()
         }
     }
 

--- a/application-module/src/test/kotlin/com/reservation/user/self/usecase/ChangeGeneralUserNicknameServiceTest.kt
+++ b/application-module/src/test/kotlin/com/reservation/user/self/usecase/ChangeGeneralUserNicknameServiceTest.kt
@@ -3,11 +3,11 @@ package com.reservation.user.self.usecase
 import com.navercorp.fixturemonkey.kotlin.giveMeOne
 import com.reservation.common.exceptions.AlreadyPersistedException
 import com.reservation.common.exceptions.NoSuchPersistedElementException
-import com.reservation.exceptions.InvalidSituationException
 import com.reservation.fixture.CommonlyUsedArbitraries
 import com.reservation.fixture.FixtureMonkeyFactory
 import com.reservation.user.history.change.port.input.CreateGeneralUserChangeHistoryUseCase
 import com.reservation.user.self.User
+import com.reservation.user.self.exceptions.UserFieldMustNotBeNullException
 import com.reservation.user.self.port.input.command.request.ChangeGeneralUserNicknameCommand
 import com.reservation.user.self.port.output.ChangeGeneralUserNickname
 import com.reservation.user.self.port.output.CheckGeneralUserNicknameDuplicated
@@ -136,7 +136,7 @@ class ChangeGeneralUserNicknameServiceTest {
                 changeUserNicknameDomainService.changePersonalAttributes(any(), any())
             } returns invalidUser
 
-            assertThrows<InvalidSituationException> {
+            assertThrows<UserFieldMustNotBeNullException> {
                 useCase.execute(command)
             }
         }

--- a/application-module/src/test/kotlin/com/reservation/user/self/usecase/ChangeGeneralUserPasswordServiceTest.kt
+++ b/application-module/src/test/kotlin/com/reservation/user/self/usecase/ChangeGeneralUserPasswordServiceTest.kt
@@ -2,10 +2,10 @@ package com.reservation.user.self.usecase
 
 import com.navercorp.fixturemonkey.kotlin.giveMeOne
 import com.reservation.common.exceptions.NoSuchPersistedElementException
-import com.reservation.exceptions.InvalidSituationException
 import com.reservation.fixture.CommonlyUsedArbitraries
 import com.reservation.fixture.FixtureMonkeyFactory
 import com.reservation.user.self.User
+import com.reservation.user.self.exceptions.UserFieldMustNotBeNullException
 import com.reservation.user.self.port.input.command.request.ChangeGeneralUserPasswordCommand
 import com.reservation.user.self.port.output.ChangeGeneralUserPassword
 import com.reservation.user.self.port.output.LoadGeneralUser
@@ -93,7 +93,7 @@ class ChangeGeneralUserPasswordServiceTest {
                 changeGeneralUserPasswordDomainService.changePassword(any(), any())
             } returns changePasswordResult
 
-            assertThrows<InvalidSituationException> {
+            assertThrows<UserFieldMustNotBeNullException> {
                 useCase.execute(command)
             }
         }
@@ -133,7 +133,7 @@ class ChangeGeneralUserPasswordServiceTest {
                 changeGeneralUserPasswordDomainService.changePassword(any(), any())
             } returns changePasswordResult
 
-            assertThrows<InvalidSituationException> {
+            assertThrows<UserFieldMustNotBeNullException> {
                 useCase.execute(command)
             }
         }
@@ -173,7 +173,7 @@ class ChangeGeneralUserPasswordServiceTest {
                 changeGeneralUserPasswordDomainService.changePassword(any(), any())
             } returns changePasswordResult
 
-            assertThrows<InvalidSituationException> {
+            assertThrows<UserFieldMustNotBeNullException> {
                 useCase.execute(command)
             }
         }

--- a/application-module/src/test/kotlin/com/reservation/user/self/usecase/FindGeneralUserPasswordServiceTest.kt
+++ b/application-module/src/test/kotlin/com/reservation/user/self/usecase/FindGeneralUserPasswordServiceTest.kt
@@ -6,6 +6,7 @@ import com.reservation.exceptions.InvalidSituationException
 import com.reservation.fixture.CommonlyUsedArbitraries
 import com.reservation.fixture.FixtureMonkeyFactory
 import com.reservation.user.self.User
+import com.reservation.user.self.exceptions.UserFieldMustNotBeNullException
 import com.reservation.user.self.port.input.query.request.FindGeneralUserPasswordCommand
 import com.reservation.user.self.port.output.LoadGeneralUserByLoginIdAndEmail
 import com.reservation.user.self.port.output.SendFindGeneralUserPasswordAsEmail
@@ -177,7 +178,7 @@ class FindGeneralUserPasswordServiceTest {
                 changeGeneralUserPasswordDomainService.changePassword(any(), any(), eq(true))
             } returns changePasswordResult
 
-            assertThrows<InvalidSituationException> {
+            assertThrows<UserFieldMustNotBeNullException> {
                 useCase.execute(command)
             }
         }

--- a/shared-module/src/main/kotlin/com/reservation/exceptions/InvalidSituationException.kt
+++ b/shared-module/src/main/kotlin/com/reservation/exceptions/InvalidSituationException.kt
@@ -1,5 +1,5 @@
 package com.reservation.exceptions
 
-open class InvalidSituationException(
+abstract class InvalidSituationException(
     message: String = "It's CRITICAL EXCEPTION",
 ) : RuntimeException(message)


### PR DESCRIPTION


## 🎫 Context

- github:
- jira:

## 📄 Summary
- exception wjdfl

## ✨ What’s Changed
- FindGeneralUserPasswordService, ChangeGeneralUserPasswordService, ChangeGeneralUserNicknameService에서
  - 기존의 InvalidSituationException을 UserFieldMustNotBeNullException으로 대체
  - null 검사 시 던지는 예외를 일관되게 교체하여 도메인 의도를 명확화
- ChangeGeneralUserPasswordService에서 user.identifier, user.userOldEncodedPassword, user.userPasswordChangedDatetime의 null 처리 로직을 UserFieldMustNotBeNullException으로 수정
- ChangeGeneralUserNicknameService에서 user.identifier null 처리 로직을 UserFieldMustNotBeNullException으로 수정
- FindGeneralUserPasswordService 테스트와 ChangeGeneralUserPasswordService 테스트에서 기대 예외를 InvalidSituationException에서 UserFieldMustNotBeNullException으로 변경
- 관련 import 문 정리 및 예외 패키지 참조 경로 업데이트

## 🧩 Motivation & Background
- exception 간 쳬계 정리

## 🔥 Impact
- `InvalidSituationException`이 Abstract가 됌

## 🚦 How to Test (검증방법)
- x

## 📝 Notes

- x