### PR TITLE
chore: gradle.properties 설정 정리 및 불필요 항목 제거 [NO_REVIEW]

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,42 +1,29 @@
-# JVM ? ??? ??? (GitHub Actions 7GB ?? ??)
 org.gradle.jvmargs=-Xmx4g -XX:+UseG1GC -XX:+UseStringDeduplication -XX:MaxGCPauseMillis=100
 
-# ?? ?? (??? ??, ???? ??)
 org.gradle.parallel=true
 org.gradle.workers.max=4
 
-# Configuration cache (OpenAPI 태스크와 호환성 문제로 비활성화)
-# com.epages.restdocs.apispec.gradle.OpenApi3Task가 Configuration cache 미지원
 org.gradle.configuration-cache=false
 org.gradle.configuration-cache.problems=warn
 
-# ?? ?? ???
 org.gradle.caching=true
 org.gradle.caching.buildcache.remote.enabled=false
 
-# ???? ?? (???? ?? ?? ??)
 org.gradle.configureondemand=true
 
-# ?? ??? ?? (GitHub Actions??? ???)
 org.gradle.vfs.watch=false
 
-# ?? ?? ??? (?? ???)
 org.gradle.console=plain
 
-# Kotlin ???? ???
 kotlin.incremental=true
 kotlin.incremental.useClasspathSnapshot=true
 kotlin.incremental.usePreciseJavaTracking=true
 kotlin.build.report.output=file
 
-# Kapt ??? (annotation processor ???)
 kapt.incremental.apt=true
 kapt.use.worker.api=true
 kapt.include.compile.classpath=false
 
-# ??? ?? ??
-# JUnit ?? ?? ???? (???? ???? ????)
 systemProp.junit.jupiter.execution.parallel.enabled=false
 
-# Spring Test Context ?? ?? ??
 systemProp.spring.test.context.cache.maxSize=30


### PR DESCRIPTION


## 🎫 Context

- github:
- jira:

## 📄 Summary
- gradle.properties 정리

## ✨ What’s Changed
- JVM 힙 설정 유지: org.gradle.jvmargs=-Xmx4g -XX:+UseG1GC -XX:+UseStringDeduplication -XX:MaxGCPauseMillis=100
- 병렬 빌드 설정 유지: org.gradle.parallel=true, org.gradle.workers.max=4
- Configuration cache 관련 불필요 주석/설정 제거 (관련 주석 삭제)
- 캐시 및 빌드옵션 정리: org.gradle.caching=true, org.gradle.caching.buildcache.remote.enabled=false
- Configure on demand 활성화 유지: org.gradle.configureondemand=true
- VFS watch 비활성화 유지: org.gradle.vfs.watch=false
- 콘솔 출력 형식 설정 유지: org.gradle.console=plain
- Kotlin 증분 빌드 관련 설정 유지: kotlin.incremental=true, kotlin.incremental.useClasspathSnapshot=true, kotlin.incremental.usePreciseJavaTracking=true, kotlin.build.report.output=file
- Kapt 관련 설정 유지 및 최적화: kapt.incremental.apt=true, kapt.use.worker.api=true, kapt.include.compile.classpath=false
- JUnit 병렬 실행 설정 관련 주석 제거 (systemProp.junit.jupiter.execution.parallel.enabled 설정 삭제)
- Spring Test Context 캐시 크기 설정 유지: systemProp.spring.test.context.cache.maxSize=30

## 🧩 Motivation & Background
- 불필요한 문자 제거

## 🔥 Impact
- x

## 🚦 How to Test (검증방법)
- x

## 📝 Notes

- x