### PR TITLE
refactor/kafka-parallel-consumer

### DIFF
--- a/adapter-module/src/main/kotlin/com/reservation/event/timetable/occupancy/TimeTableOccupiedDomainEventListener.kt
+++ b/adapter-module/src/main/kotlin/com/reservation/event/timetable/occupancy/TimeTableOccupiedDomainEventListener.kt
@@ -1,12 +1,16 @@
 package com.reservation.event.timetable.occupancy
 
+import com.fasterxml.jackson.databind.ObjectMapper
 import com.reservation.common.exceptions.NoSuchPersistedElementException
 import com.reservation.enumeration.OutboxEventType
 import com.reservation.enumeration.OutboxEventType.TIME_TABLE_OCCUPIED
 import com.reservation.event.abstractEvent.AbstractEvent
+import com.reservation.kafka.config.KafkaHeader.ORIGINAL_TOPIC_KEY
+import com.reservation.kafka.config.KafkaHeader.RETRY_COUNT_KEY
 import com.reservation.persistence.outbox.entity.OutBox
 import com.reservation.persistence.outbox.repository.OutboxRepository
 import com.reservation.timetable.event.TimeTableOccupiedDomainEvent
+import org.apache.kafka.clients.producer.ProducerRecord
 import org.springframework.context.ApplicationEventPublisher
 import org.springframework.kafka.core.KafkaTemplate
 import org.springframework.stereotype.Component
@@ -20,9 +24,10 @@ import java.util.concurrent.TimeUnit.SECONDS
 
 @Component
 class TimeTableOccupiedDomainEventListener(
-    private val kafkaTemplate: KafkaTemplate<String, AbstractEvent>,
+    private val kafkaTemplate: KafkaTemplate<String, String>,
     private val repository: OutboxRepository,
     private val applicationEventPublisher: ApplicationEventPublisher,
+    private val objectMapper: ObjectMapper,
 ) {
     companion object {
         const val TIME_TABLE_OCCUPIED_EVENT_VERSION = 1.0
@@ -60,7 +65,17 @@ class TimeTableOccupiedDomainEventListener(
                 .orElseThrow { throw NoSuchPersistedElementException() }
 
         runCatching {
-            kafkaTemplate.send(kafkaTopic, kafkaKey, createdEvent)
+            val record =
+                ProducerRecord(
+                    kafkaTopic,
+                    kafkaKey,
+                    objectMapper.writeValueAsString(createdEvent),
+                )
+
+            record.headers().add(RETRY_COUNT_KEY, "0".toByteArray(Charsets.UTF_8))
+            record.headers().add(ORIGINAL_TOPIC_KEY, kafkaTopic.toByteArray(Charsets.UTF_8))
+
+            kafkaTemplate.send(record)
                 .get(KAFKA_EVENT_PUBLISH_TIME_OUT, SECONDS)
         }
             .onSuccess { outbox.succeeded() }

--- a/adapter-module/src/main/kotlin/com/reservation/kafka/adapter/TimeTableOccupancyKafkaListener.kt
+++ b/adapter-module/src/main/kotlin/com/reservation/kafka/adapter/TimeTableOccupancyKafkaListener.kt
@@ -1,5 +1,7 @@
 package com.reservation.kafka.adapter
 
+import com.fasterxml.jackson.core.JsonProcessingException
+import com.fasterxml.jackson.databind.ObjectMapper
 import com.reservation.httpinterface.exceptions.ResponseBodyRequiredException
 import com.reservation.httpinterface.timetable.FindTimeTableOccupancyHttpInterface
 import com.reservation.httpinterface.timetable.response.FindTimeTableOccupancyInternallyHttpInterfaceResponse
@@ -8,23 +10,81 @@ import com.reservation.reservation.port.input.CreateReservationUseCase
 import com.reservation.reservation.port.input.IsReservationExistsUseCase
 import com.reservation.reservation.port.input.command.CreateReservationCommand
 import com.reservation.reservation.port.input.query.IsReservationExistsQuery
-import org.springframework.kafka.annotation.KafkaListener
-import org.springframework.kafka.support.Acknowledgment
-import org.springframework.kafka.support.KafkaHeaders
-import org.springframework.messaging.handler.annotation.Header
-import org.springframework.messaging.handler.annotation.Payload
+import com.reservation.utilities.logger.loggerFactory
+import io.confluent.parallelconsumer.ParallelStreamProcessor
+import io.confluent.parallelconsumer.internal.DrainingCloseable.DrainingMode.DRAIN
+import jakarta.annotation.PostConstruct
+import jakarta.annotation.PreDestroy
+import org.apache.kafka.clients.producer.ProducerRecord
+import org.springframework.kafka.core.KafkaTemplate
 import org.springframework.stereotype.Component
-import java.time.Duration
+import java.time.Instant
+import java.util.concurrent.TimeUnit
 
 @Component
 class TimeTableOccupancyKafkaListener(
     private val httpInterface: FindTimeTableOccupancyHttpInterface,
     private val createReservationUseCase: CreateReservationUseCase,
     private val isReservationExistsUseCase: IsReservationExistsUseCase,
+    private val parallelEventConsumer: ParallelStreamProcessor<String, String>,
+    private val objectMapper: ObjectMapper,
+    private val kafkaTemplate: KafkaTemplate<String, String>,
 ) {
+    private val log = loggerFactory<TimeTableOccupancyKafkaListener>()
+
     companion object {
-        const val TOPIC = "OutboxEventType"
+        const val TOPIC = "time-table-occupancy"
+        const val DLT_SUFFIX = "dlt"
         const val GROUP_ID = "reservation-service"
+        const val RETRY_ATTEMPTS = 3
+        const val BACK_OFF_DELAY = 1000
+        const val BACK_OFF_MULTIPLIER = 2.0
+        const val WAIT_FOR_GET_TIME = 5L
+    }
+
+    @PostConstruct
+    fun init() {
+        parallelEventConsumer.subscribe(listOf(TOPIC))
+        parallelEventConsumer.poll { context ->
+            val record = context.singleRecord
+            val key = record.key()
+            val payloadString = record.value()
+
+            val payload =
+                try {
+                    objectMapper.readValue(
+                        payloadString,
+                        TimeTableOccupancyReceivedEvent::class.java,
+                    )
+                } catch (e: JsonProcessingException) {
+                    log.error("INVALID JSON", e)
+
+                    onHandleDlt(TOPIC, key, e.toString(), payloadString)
+                    return@poll
+                }
+
+            repeat(RETRY_ATTEMPTS) { attempt ->
+                runCatching {
+                    onEventHandler(payload)
+                }
+                    .onFailure { error ->
+                        log.error("Error in TimeTableOccupancyEvent:", error)
+                        log.error("retry: {}", attempt)
+
+                        if (attempt < RETRY_ATTEMPTS - 1) {
+                            val backOff = BACK_OFF_DELAY * ((attempt + 1) * BACK_OFF_MULTIPLIER)
+                            Thread.sleep(backOff.toLong())
+                        }
+                    }
+            }
+
+            onHandleDlt(TOPIC, key, "Max retries exceeded", payloadString)
+        }
+    }
+
+    @PreDestroy
+    fun destroy() {
+        parallelEventConsumer.close(DRAIN)
     }
 
     private fun isExists(
@@ -36,34 +96,6 @@ class TimeTableOccupancyKafkaListener(
             timeTableOccupancyId = timeTableOccupancyId,
         ),
     )
-
-    @KafkaListener(
-        topics = [TOPIC],
-        groupId = GROUP_ID,
-    )
-    fun createReservationHandler(
-        @Header(KafkaHeaders.ACKNOWLEDGMENT) ack: Acknowledgment,
-        @Payload event: TimeTableOccupancyReceivedEvent,
-    ) {
-        runCatching {
-            val timeTableId = event.timeTableId
-            val timeTableOccupancyId = event.timeTableOccupancyId
-
-            if (isExists(timeTableId, timeTableOccupancyId)) {
-                return
-            }
-
-            val responseEntity =
-                httpInterface.findTimeTableOccupancyInternally(
-                    timeTableId = timeTableId,
-                    timeTableOccupancyId = timeTableOccupancyId,
-                )
-
-            createReservation(responseEntity.body)
-        }
-            .onSuccess { ack.acknowledge() }
-            .onFailure { ack.nack(Duration.ofMinutes(1)) }
-    }
 
     private fun createReservationCommand(
         httpInterfaceResponse: FindTimeTableOccupancyInternallyHttpInterfaceResponse,
@@ -93,5 +125,59 @@ class TimeTableOccupancyKafkaListener(
 
         val command = createReservationCommand(body)
         createReservationUseCase.execute(command)
+    }
+
+    private fun onEventHandler(event: TimeTableOccupancyReceivedEvent) {
+        val timeTableId = event.timeTableId
+        val timeTableOccupancyId = event.timeTableOccupancyId
+
+        if (isExists(timeTableId, timeTableOccupancyId)) {
+            return
+        }
+
+        val responseEntity =
+            httpInterface.findTimeTableOccupancyInternally(
+                timeTableId = timeTableId,
+                timeTableOccupancyId = timeTableOccupancyId,
+            )
+
+        createReservation(responseEntity.body)
+    }
+
+    fun onHandleDlt(
+        originalTopic: String,
+        partitionKey: String,
+        error: String,
+        event: String,
+    ) {
+        log.error(
+            """
+            original topic: {},
+            error: {}
+            event: {}
+            """.trimIndent(),
+            originalTopic,
+            error,
+            event,
+        )
+
+
+        val dltRecord =
+            ProducerRecord<String, String>(
+                "$originalTopic-$DLT_SUFFIX", // topic
+                partitionKey, // key (positional)
+                event, // value (positional)
+            ).apply {
+                headers().add("original-topic", originalTopic.toByteArray())
+                headers().add("error-reason", error.toByteArray())
+                headers().add("failed-timestamp", Instant.now().toString().toByteArray())
+            }
+
+
+        runCatching {
+            kafkaTemplate.send(dltRecord).get(WAIT_FOR_GET_TIME, TimeUnit.SECONDS)
+            log.error("Sent to DLT: topic=${dltRecord.topic()}, key=$partitionKey")
+        }
+            .onFailure { e -> log.error("CRITICAL: Failed to send to DLT", e) }
     }
 }

--- a/adapter-module/src/main/kotlin/com/reservation/kafka/adapter/TimeTableOccupancyKafkaListener.kt
+++ b/adapter-module/src/main/kotlin/com/reservation/kafka/adapter/TimeTableOccupancyKafkaListener.kt
@@ -63,19 +63,20 @@ class TimeTableOccupancyKafkaListener(
                 }
 
             repeat(RETRY_ATTEMPTS) { attempt ->
-                val isSuccess = runCatching {
-                    onEventHandler(payload)
-                }
-                    .onFailure { error ->
-                        log.error("Error in TimeTableOccupancyEvent:", error)
-                        log.error("retry: {}", attempt)
-
-                        if (attempt < RETRY_ATTEMPTS - 1) {
-                            val backOff = BACK_OFF_DELAY * ((attempt + 1) * BACK_OFF_MULTIPLIER)
-                            Thread.sleep(backOff.toLong())
-                        }
+                val isSuccess =
+                    runCatching {
+                        onEventHandler(payload)
                     }
-                    .isSuccess
+                        .onFailure { error ->
+                            log.error("Error in TimeTableOccupancyEvent:", error)
+                            log.error("retry: {}", attempt)
+
+                            if (attempt < RETRY_ATTEMPTS - 1) {
+                                val backOff = BACK_OFF_DELAY * ((attempt + 1) * BACK_OFF_MULTIPLIER)
+                                Thread.sleep(backOff.toLong())
+                            }
+                        }
+                        .isSuccess
 
                 if (isSuccess) return@poll
             }

--- a/adapter-module/src/main/kotlin/com/reservation/kafka/adapter/TimeTableOccupancyKafkaListener.kt
+++ b/adapter-module/src/main/kotlin/com/reservation/kafka/adapter/TimeTableOccupancyKafkaListener.kt
@@ -127,7 +127,7 @@ class TimeTableOccupancyKafkaListener(
         createReservationUseCase.execute(command)
     }
 
-    private fun onEventHandler(event: TimeTableOccupancyReceivedEvent) {
+    fun onEventHandler(event: TimeTableOccupancyReceivedEvent) {
         val timeTableId = event.timeTableId
         val timeTableOccupancyId = event.timeTableOccupancyId
 
@@ -161,7 +161,6 @@ class TimeTableOccupancyKafkaListener(
             event,
         )
 
-
         val dltRecord =
             ProducerRecord<String, String>(
                 "$originalTopic-$DLT_SUFFIX", // topic
@@ -172,7 +171,6 @@ class TimeTableOccupancyKafkaListener(
                 headers().add("error-reason", error.toByteArray())
                 headers().add("failed-timestamp", Instant.now().toString().toByteArray())
             }
-
 
         runCatching {
             kafkaTemplate.send(dltRecord).get(WAIT_FOR_GET_TIME, TimeUnit.SECONDS)

--- a/adapter-module/src/main/kotlin/com/reservation/kafka/adapter/TimeTableOccupancyKafkaListener.kt
+++ b/adapter-module/src/main/kotlin/com/reservation/kafka/adapter/TimeTableOccupancyKafkaListener.kt
@@ -81,7 +81,7 @@ class TimeTableOccupancyKafkaListener(
                 return@poll
             }
 
-            val payload: TimeTableOccupancyReceivedEvent? = parseJson(key, payloadString)
+            val payload: TimeTableOccupancyReceivedEvent? = parseJson(key, headers, payloadString)
             if (payload == null) return@poll
 
             runCatching { onEventHandler(payload) }
@@ -137,6 +137,7 @@ class TimeTableOccupancyKafkaListener(
 
     private fun parseJson(
         key: String,
+        header: Headers,
         payloadString: String,
     ): TimeTableOccupancyReceivedEvent? =
         try {
@@ -146,7 +147,7 @@ class TimeTableOccupancyKafkaListener(
             )
         } catch (e: JsonProcessingException) {
             log.error("INVALID JSON", e)
-            onHandleDlt(TOPIC, key, e.toString(), payloadString)
+            onHandleDlt(TOPIC, key, header, e.toString(), payloadString)
             null
         }
 

--- a/adapter-module/src/main/kotlin/com/reservation/kafka/adapter/TimeTableOccupancyKafkaListener.kt
+++ b/adapter-module/src/main/kotlin/com/reservation/kafka/adapter/TimeTableOccupancyKafkaListener.kt
@@ -5,6 +5,8 @@ import com.fasterxml.jackson.databind.ObjectMapper
 import com.reservation.httpinterface.exceptions.ResponseBodyRequiredException
 import com.reservation.httpinterface.timetable.FindTimeTableOccupancyHttpInterface
 import com.reservation.httpinterface.timetable.response.FindTimeTableOccupancyInternallyHttpInterfaceResponse
+import com.reservation.kafka.config.KafkaHeader.ERROR_REASON_KEY
+import com.reservation.kafka.config.KafkaHeader.FAILED_TIMESTAMP_KEY
 import com.reservation.kafka.config.KafkaHeader.ORIGINAL_TOPIC_KEY
 import com.reservation.kafka.config.KafkaHeader.RETRY_COUNT_KEY
 import com.reservation.kafka.event.TimeTableOccupancyReceivedEvent
@@ -21,6 +23,7 @@ import org.apache.kafka.clients.producer.ProducerRecord
 import org.apache.kafka.common.header.Headers
 import org.springframework.kafka.core.KafkaTemplate
 import org.springframework.stereotype.Component
+import java.nio.charset.StandardCharsets
 import java.time.Duration
 import java.time.Instant
 import java.util.concurrent.TimeUnit
@@ -67,8 +70,14 @@ class TimeTableOccupancyKafkaListener(
             val headers = record.headers()
 
             val retryCount = retryCount(headers)
-            if (retryCount > RETRY_ATTEMPTS) {
-                onHandleDlt(TOPIC, key, "Retry-count exceeded ($retryCount).", payloadString)
+            if (retryCount + ADD_RETRY_COUNT >= RETRY_ATTEMPTS) {
+                onHandleDlt(
+                    originalTopic = TOPIC,
+                    partitionKey = key,
+                    headers = headers,
+                    error = "Retry-count exceeded ($retryCount).",
+                    event = payloadString,
+                )
                 return@poll
             }
 
@@ -142,13 +151,12 @@ class TimeTableOccupancyKafkaListener(
         }
 
     private fun originalTopic(header: Headers) =
-        header.lastHeader(ORIGINAL_TOPIC_KEY)
-            ?.let { String(it.value()) }
+        header.lastHeader(ORIGINAL_TOPIC_KEY)?.let { String(it.value(), StandardCharsets.UTF_8) }
             ?: TOPIC
 
     private fun retryCount(header: Headers) =
         header.lastHeader(RETRY_COUNT_KEY)
-            ?.let { String(it.value()).toInt() }
+            ?.let { String(it.value(), StandardCharsets.UTF_8).toIntOrNull() }
             ?: 0
 
     private fun retry(
@@ -167,10 +175,11 @@ class TimeTableOccupancyKafkaListener(
                 payloadString,
             )
 
-        record.headers().add(RETRY_COUNT_KEY, retryCount.toString().toByteArray(Charsets.UTF_8))
-        record.headers().add(ORIGINAL_TOPIC_KEY, originalTopic.toByteArray(Charsets.UTF_8))
+        record.headers()
+            .add(RETRY_COUNT_KEY, retryCount.toString().toByteArray(StandardCharsets.UTF_8))
+        record.headers().add(ORIGINAL_TOPIC_KEY, originalTopic.toByteArray(StandardCharsets.UTF_8))
 
-        kafkaTemplate.send(record)
+        kafkaTemplate.send(record).thenAccept { log.info("Result: $it") }
     }
 
     private fun createReservation(body: FindTimeTableOccupancyInternallyHttpInterfaceResponse?) {
@@ -182,7 +191,7 @@ class TimeTableOccupancyKafkaListener(
         createReservationUseCase.execute(command)
     }
 
-    private fun onEventHandler(event: TimeTableOccupancyReceivedEvent) {
+    fun onEventHandler(event: TimeTableOccupancyReceivedEvent) {
         val timeTableId = event.timeTableId
         val timeTableOccupancyId = event.timeTableOccupancyId
 
@@ -199,9 +208,10 @@ class TimeTableOccupancyKafkaListener(
         createReservation(responseEntity.body)
     }
 
-    private fun onHandleDlt(
+    fun onHandleDlt(
         originalTopic: String,
         partitionKey: String,
+        headers: Headers,
         error: String,
         event: String,
     ) {
@@ -222,9 +232,9 @@ class TimeTableOccupancyKafkaListener(
                 partitionKey, // key (positional)
                 event, // value (positional)
             ).apply {
-                headers().add("original-topic", originalTopic.toByteArray())
-                headers().add("error-reason", error.toByteArray())
-                headers().add("failed-timestamp", Instant.now().toString().toByteArray())
+                headers().add(ORIGINAL_TOPIC_KEY, headers.lastHeader(ORIGINAL_TOPIC_KEY).value())
+                headers().add(ERROR_REASON_KEY, error.toByteArray())
+                headers().add(FAILED_TIMESTAMP_KEY, Instant.now().toString().toByteArray())
             }
 
         runCatching {

--- a/adapter-module/src/main/kotlin/com/reservation/kafka/adapter/TimeTableOccupancyKafkaListener.kt
+++ b/adapter-module/src/main/kotlin/com/reservation/kafka/adapter/TimeTableOccupancyKafkaListener.kt
@@ -165,7 +165,7 @@ class TimeTableOccupancyKafkaListener(
         )
 
         val dltRecord =
-            ProducerRecord<String, String>(
+            ProducerRecord(
                 "$originalTopic-$DLT_SUFFIX", // topic
                 partitionKey, // key (positional)
                 event, // value (positional)

--- a/adapter-module/src/main/kotlin/com/reservation/kafka/adapter/TimeTableOccupancyKafkaListener.kt
+++ b/adapter-module/src/main/kotlin/com/reservation/kafka/adapter/TimeTableOccupancyKafkaListener.kt
@@ -17,6 +17,7 @@ import jakarta.annotation.PreDestroy
 import org.apache.kafka.clients.producer.ProducerRecord
 import org.springframework.kafka.core.KafkaTemplate
 import org.springframework.stereotype.Component
+import java.time.Duration
 import java.time.Instant
 import java.util.concurrent.TimeUnit
 
@@ -87,7 +88,7 @@ class TimeTableOccupancyKafkaListener(
 
     @PreDestroy
     fun destroy() {
-        parallelEventConsumer.close()
+        parallelEventConsumer.closeDrainFirst(Duration.ofSeconds(30))
     }
 
     private fun isExists(

--- a/adapter-module/src/main/kotlin/com/reservation/kafka/adapter/TimeTableOccupancyKafkaListener.kt
+++ b/adapter-module/src/main/kotlin/com/reservation/kafka/adapter/TimeTableOccupancyKafkaListener.kt
@@ -5,6 +5,8 @@ import com.fasterxml.jackson.databind.ObjectMapper
 import com.reservation.httpinterface.exceptions.ResponseBodyRequiredException
 import com.reservation.httpinterface.timetable.FindTimeTableOccupancyHttpInterface
 import com.reservation.httpinterface.timetable.response.FindTimeTableOccupancyInternallyHttpInterfaceResponse
+import com.reservation.kafka.config.KafkaHeader.ORIGINAL_TOPIC_KEY
+import com.reservation.kafka.config.KafkaHeader.RETRY_COUNT_KEY
 import com.reservation.kafka.event.TimeTableOccupancyReceivedEvent
 import com.reservation.reservation.port.input.CreateReservationUseCase
 import com.reservation.reservation.port.input.IsReservationExistsUseCase
@@ -14,7 +16,9 @@ import com.reservation.utilities.logger.loggerFactory
 import io.confluent.parallelconsumer.ParallelStreamProcessor
 import jakarta.annotation.PostConstruct
 import jakarta.annotation.PreDestroy
+import kotlin.math.pow
 import org.apache.kafka.clients.producer.ProducerRecord
+import org.apache.kafka.common.header.Headers
 import org.springframework.kafka.core.KafkaTemplate
 import org.springframework.stereotype.Component
 import java.time.Duration
@@ -22,13 +26,14 @@ import java.time.Instant
 import java.util.concurrent.TimeUnit
 
 @Component
+@SuppressWarnings("TooManyFunctions")
 class TimeTableOccupancyKafkaListener(
     private val httpInterface: FindTimeTableOccupancyHttpInterface,
     private val createReservationUseCase: CreateReservationUseCase,
     private val isReservationExistsUseCase: IsReservationExistsUseCase,
+    private val kafkaTemplate: KafkaTemplate<String, String>,
     private val parallelEventConsumer: ParallelStreamProcessor<String, String>,
     private val objectMapper: ObjectMapper,
-    private val kafkaTemplate: KafkaTemplate<String, String>,
 ) {
     private val log = loggerFactory<TimeTableOccupancyKafkaListener>()
 
@@ -40,55 +45,54 @@ class TimeTableOccupancyKafkaListener(
         const val BACK_OFF_DELAY = 1000
         const val BACK_OFF_MULTIPLIER = 2.0
         const val WAIT_FOR_GET_TIME = 5L
+        const val DRAIN_DURATION = 30L
+        const val ADD_RETRY_COUNT = 1
     }
 
     @PostConstruct
     fun init() {
-        parallelEventConsumer.subscribe(listOf(TOPIC))
+        val topics = mutableListOf<String>()
+        repeat(RETRY_ATTEMPTS) {
+            when (it) {
+                0 -> topics.add(TOPIC)
+                else -> topics.add("$TOPIC-RETRY-$it")
+            }
+        }
+
+        parallelEventConsumer.subscribe(topics)
         parallelEventConsumer.poll { context ->
             val record = context.singleRecord
             val key = record.key()
             val payloadString = record.value()
+            val headers = record.headers()
 
-            val payload =
-                try {
-                    objectMapper.readValue(
-                        payloadString,
-                        TimeTableOccupancyReceivedEvent::class.java,
-                    )
-                } catch (e: JsonProcessingException) {
-                    log.error("INVALID JSON", e)
-
-                    onHandleDlt(TOPIC, key, e.toString(), payloadString)
-                    return@poll
-                }
-
-            repeat(RETRY_ATTEMPTS) { attempt ->
-                val isSuccess =
-                    runCatching {
-                        onEventHandler(payload)
-                    }
-                        .onFailure { error ->
-                            log.error("Error in TimeTableOccupancyEvent:", error)
-                            log.error("retry: {}", attempt)
-
-                            if (attempt < RETRY_ATTEMPTS - 1) {
-                                val backOff = BACK_OFF_DELAY * ((attempt + 1) * BACK_OFF_MULTIPLIER)
-                                Thread.sleep(backOff.toLong())
-                            }
-                        }
-                        .isSuccess
-
-                if (isSuccess) return@poll
+            val retryCount = retryCount(headers)
+            if (retryCount > RETRY_ATTEMPTS) {
+                onHandleDlt(TOPIC, key, "Retry-count exceeded ($retryCount).", payloadString)
+                return@poll
             }
 
-            onHandleDlt(TOPIC, key, "Max retries exceeded", payloadString)
+            val payload: TimeTableOccupancyReceivedEvent? = parseJson(key, payloadString)
+            if (payload == null) return@poll
+
+            runCatching { onEventHandler(payload) }
+                .onFailure { error ->
+                    log.error("Error in TimeTableOccupancyEvent:", error)
+                    try {
+                        val backOff =
+                            BACK_OFF_DELAY * BACK_OFF_MULTIPLIER.pow((retryCount + ADD_RETRY_COUNT))
+                        Thread.sleep(backOff.toLong())
+                        retry(headers, kafkaKey = key, payloadString)
+                    } catch (e: InterruptedException) {
+                        Thread.currentThread().interrupt()
+                    }
+                }
         }
     }
 
     @PreDestroy
     fun destroy() {
-        parallelEventConsumer.closeDrainFirst(Duration.ofSeconds(30))
+        parallelEventConsumer.closeDrainFirst(Duration.ofSeconds(DRAIN_DURATION))
     }
 
     private fun isExists(
@@ -122,6 +126,53 @@ class TimeTableOccupancyKafkaListener(
         )
     }
 
+    private fun parseJson(
+        key: String,
+        payloadString: String,
+    ): TimeTableOccupancyReceivedEvent? =
+        try {
+            objectMapper.readValue(
+                payloadString,
+                TimeTableOccupancyReceivedEvent::class.java,
+            )
+        } catch (e: JsonProcessingException) {
+            log.error("INVALID JSON", e)
+            onHandleDlt(TOPIC, key, e.toString(), payloadString)
+            null
+        }
+
+    private fun originalTopic(header: Headers) =
+        header.lastHeader(ORIGINAL_TOPIC_KEY)
+            ?.let { String(it.value()) }
+            ?: TOPIC
+
+    private fun retryCount(header: Headers) =
+        header.lastHeader(RETRY_COUNT_KEY)
+            ?.let { String(it.value()).toInt() }
+            ?: 0
+
+    private fun retry(
+        header: Headers,
+        kafkaKey: String,
+        payloadString: String,
+    ) {
+        val originalTopic = originalTopic(header)
+        val retryCount = retryCount(header) + ADD_RETRY_COUNT
+        val topic = "$originalTopic-RETRY-$retryCount"
+
+        val record =
+            ProducerRecord(
+                topic,
+                kafkaKey,
+                payloadString,
+            )
+
+        record.headers().add(RETRY_COUNT_KEY, retryCount.toString().toByteArray(Charsets.UTF_8))
+        record.headers().add(ORIGINAL_TOPIC_KEY, originalTopic.toByteArray(Charsets.UTF_8))
+
+        kafkaTemplate.send(record)
+    }
+
     private fun createReservation(body: FindTimeTableOccupancyInternallyHttpInterfaceResponse?) {
         if (body == null) {
             throw ResponseBodyRequiredException()
@@ -131,7 +182,7 @@ class TimeTableOccupancyKafkaListener(
         createReservationUseCase.execute(command)
     }
 
-    fun onEventHandler(event: TimeTableOccupancyReceivedEvent) {
+    private fun onEventHandler(event: TimeTableOccupancyReceivedEvent) {
         val timeTableId = event.timeTableId
         val timeTableOccupancyId = event.timeTableOccupancyId
 
@@ -148,7 +199,7 @@ class TimeTableOccupancyKafkaListener(
         createReservation(responseEntity.body)
     }
 
-    fun onHandleDlt(
+    private fun onHandleDlt(
         originalTopic: String,
         partitionKey: String,
         error: String,

--- a/adapter-module/src/main/kotlin/com/reservation/kafka/config/KafkaConfig.kt
+++ b/adapter-module/src/main/kotlin/com/reservation/kafka/config/KafkaConfig.kt
@@ -132,13 +132,13 @@ class KafkaConfig(
         return configMap
     }
 
-    private inline fun <reified T> parallelConsumerOptions(
+    private fun createParallelConsumerOptions(
         kafkaProperties: KafkaProperties,
-    ): ParallelConsumerOptionsBuilder<String, T> {
+    ): ParallelConsumerOptionsBuilder<String, String> {
         val configProps = createConsumerConfig(kafkaProperties)
-        val kafkaConsumer = KafkaConsumer<String, T>(configProps)
+        val kafkaConsumer = KafkaConsumer<String, String>(configProps)
 
-        return ParallelConsumerOptions.builder<String, T>()
+        return ParallelConsumerOptions.builder<String, String>()
             .ordering(parallelConsumerProperties.processingOrder) // KEY, PARTITION, UNORDERED
             .maxConcurrency(parallelConsumerProperties.maxConcurrency)
             .consumer(kafkaConsumer) // KafkaConsumer 직접 전달
@@ -149,7 +149,7 @@ class KafkaConfig(
         kafkaProperties: KafkaProperties,
     ): ParallelStreamProcessor<String, String> {
         val consumer =
-            parallelConsumerOptions<String>(kafkaProperties)
+            createParallelConsumerOptions(kafkaProperties)
                 .shutdownTimeout(Duration.ofSeconds(TEN_SECONDS))
                 .build()
 

--- a/adapter-module/src/main/kotlin/com/reservation/kafka/config/KafkaConfig.kt
+++ b/adapter-module/src/main/kotlin/com/reservation/kafka/config/KafkaConfig.kt
@@ -2,6 +2,7 @@ package com.reservation.kafka.config
 
 import com.reservation.event.abstractEvent.AbstractEvent
 import io.confluent.parallelconsumer.ParallelConsumerOptions
+import io.confluent.parallelconsumer.ParallelConsumerOptions.ParallelConsumerOptionsBuilder
 import io.confluent.parallelconsumer.ParallelStreamProcessor
 import org.apache.kafka.clients.consumer.ConsumerConfig
 import org.apache.kafka.clients.consumer.KafkaConsumer
@@ -13,6 +14,7 @@ import org.springframework.kafka.annotation.EnableKafka
 import org.springframework.kafka.core.DefaultKafkaProducerFactory
 import org.springframework.kafka.core.KafkaTemplate
 import org.springframework.kafka.core.ProducerFactory
+import java.time.Duration
 
 @Configuration
 @EnableKafka
@@ -32,6 +34,7 @@ class KafkaConfig(
         const val MAX_POLL_RECORDS = "max.poll.records"
         const val FETCH_MIN_BYTES = "fetch.min.bytes"
         const val FETCH_MAX_WAIT_MS = "fetch.max.wait.ms"
+        const val TEN_SECONDS = 10L
     }
 
     private fun createProducerConfig(kafkaProperties: KafkaProperties): Map<String, Any> {
@@ -129,23 +132,27 @@ class KafkaConfig(
         return configMap
     }
 
-    @Bean
-    fun parallelConsumerOptions(
+    private inline fun <reified T> parallelConsumerOptions(
         kafkaProperties: KafkaProperties,
-    ): ParallelConsumerOptions<String, Any> {
+    ): ParallelConsumerOptionsBuilder<String, T> {
         val configProps = createConsumerConfig(kafkaProperties)
-        val kafkaConsumer = KafkaConsumer<String, Any>(configProps)
+        val kafkaConsumer = KafkaConsumer<String, T>(configProps)
 
-        return ParallelConsumerOptions.builder<String, Any>()
+        return ParallelConsumerOptions.builder<String, T>()
             .ordering(parallelConsumerProperties.processingOrder) // KEY, PARTITION, UNORDERED
             .maxConcurrency(parallelConsumerProperties.maxConcurrency)
             .consumer(kafkaConsumer) // KafkaConsumer 직접 전달
-            .build()
     }
 
     @Bean
-    fun parallelEasyConsumer(
-        options: ParallelConsumerOptions<String, Any>,
-    ): ParallelStreamProcessor<String, Any> =
-        ParallelStreamProcessor.createEosStreamProcessor(options)
+    fun parallelConsumer(
+        kafkaProperties: KafkaProperties,
+    ): ParallelStreamProcessor<String, String> {
+        val consumer =
+            parallelConsumerOptions<String>(kafkaProperties)
+                .shutdownTimeout(Duration.ofSeconds(TEN_SECONDS))
+                .build()
+
+        return ParallelStreamProcessor.createEosStreamProcessor(consumer)
+    }
 }

--- a/adapter-module/src/main/kotlin/com/reservation/kafka/config/KafkaConfig.kt
+++ b/adapter-module/src/main/kotlin/com/reservation/kafka/config/KafkaConfig.kt
@@ -1,6 +1,5 @@
 package com.reservation.kafka.config
 
-import com.reservation.event.abstractEvent.AbstractEvent
 import io.confluent.parallelconsumer.ParallelConsumerOptions
 import io.confluent.parallelconsumer.ParallelConsumerOptions.ParallelConsumerOptionsBuilder
 import io.confluent.parallelconsumer.ParallelStreamProcessor
@@ -81,17 +80,15 @@ class KafkaConfig(
     }
 
     @Bean
-    fun kafkaProducerFactory(
-        kafkaProperties: KafkaProperties,
-    ): ProducerFactory<String, AbstractEvent> {
+    fun kafkaProducerFactory(kafkaProperties: KafkaProperties): ProducerFactory<String, String> {
         val configProps = createProducerConfig(kafkaProperties)
         return DefaultKafkaProducerFactory(configProps)
     }
 
     @Bean
     fun kafkaTemplate(
-        producerFactory: ProducerFactory<String, AbstractEvent>,
-    ): KafkaTemplate<String, AbstractEvent> = KafkaTemplate(producerFactory)
+        producerFactory: ProducerFactory<String, String>,
+    ): KafkaTemplate<String, String> = KafkaTemplate(producerFactory)
 
     private fun createConsumerConfig(kafkaProperties: KafkaProperties): Map<String, Any> {
         val consumerConfig = kafkaProperties.consumer

--- a/adapter-module/src/main/kotlin/com/reservation/kafka/config/KafkaHeader.kt
+++ b/adapter-module/src/main/kotlin/com/reservation/kafka/config/KafkaHeader.kt
@@ -1,0 +1,7 @@
+package com.reservation.kafka.config
+
+object KafkaHeader {
+    const val RETRY_COUNT_KEY = "x-retry-count"
+    const val RETRY_INTERVAL = 1000
+    const val ORIGINAL_TOPIC_KEY = "x-original-topic"
+}

--- a/adapter-module/src/main/kotlin/com/reservation/kafka/config/KafkaHeader.kt
+++ b/adapter-module/src/main/kotlin/com/reservation/kafka/config/KafkaHeader.kt
@@ -2,6 +2,7 @@ package com.reservation.kafka.config
 
 object KafkaHeader {
     const val RETRY_COUNT_KEY = "x-retry-count"
-    const val RETRY_INTERVAL = 1000
     const val ORIGINAL_TOPIC_KEY = "x-original-topic"
+    const val ERROR_REASON_KEY = "x-error-reason"
+    const val FAILED_TIMESTAMP_KEY = "x-failed-timestamp"
 }

--- a/adapter-module/src/main/kotlin/com/reservation/kafka/event/TimeTableOccupancyReceivedEvent.kt
+++ b/adapter-module/src/main/kotlin/com/reservation/kafka/event/TimeTableOccupancyReceivedEvent.kt
@@ -1,4 +1,4 @@
-package com.reservation.kafka.listener.event
+package com.reservation.kafka.event
 
 import com.reservation.enumeration.OutboxEventType
 import java.time.LocalDateTime

--- a/adapter-module/src/main/kotlin/com/reservation/kafka/listener/TimeTableOccupancyKafkaListener.kt
+++ b/adapter-module/src/main/kotlin/com/reservation/kafka/listener/TimeTableOccupancyKafkaListener.kt
@@ -1,5 +1,7 @@
 package com.reservation.kafka.listener
 
+import com.fasterxml.jackson.core.JsonProcessingException
+import com.fasterxml.jackson.databind.ObjectMapper
 import com.reservation.httpinterface.exceptions.ResponseBodyRequiredException
 import com.reservation.httpinterface.timetable.FindTimeTableOccupancyHttpInterface
 import com.reservation.httpinterface.timetable.response.FindTimeTableOccupancyInternallyHttpInterfaceResponse

--- a/adapter-module/src/test/kotlin/com/reservation/event/timetable/occupancy/TimeTableOccupiedDomainEventListenerTest.kt
+++ b/adapter-module/src/test/kotlin/com/reservation/event/timetable/occupancy/TimeTableOccupiedDomainEventListenerTest.kt
@@ -2,10 +2,8 @@ package com.reservation.event.timetable.occupancy
 
 import com.ninjasquad.springmockk.MockkBean
 import com.ninjasquad.springmockk.SpykBean
-import com.reservation.enumeration.OutboxEventType.TIME_TABLE_OCCUPIED
 import com.reservation.enumeration.TableStatus
 import com.reservation.enumeration.TimeTableConfirmStatus
-import com.reservation.event.abstractEvent.AbstractEvent
 import com.reservation.timetable.TimeTable
 import com.reservation.timetable.port.input.command.request.CreateTimeTableOccupancyCommand
 import com.reservation.timetable.port.output.CreateTimeTableOccupancy
@@ -17,6 +15,7 @@ import io.mockk.verify
 import jakarta.annotation.PostConstruct
 import org.apache.kafka.clients.admin.AdminClient
 import org.apache.kafka.clients.admin.NewTopic
+import org.apache.kafka.clients.producer.ProducerRecord
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
@@ -100,7 +99,7 @@ class TimeTableOccupiedDomainEventListenerTest {
     private lateinit var createTimeTableOccupancy: CreateTimeTableOccupancy
 
     @SpykBean
-    private lateinit var kafkaTemplate: KafkaTemplate<String, AbstractEvent>
+    private lateinit var kafkaTemplate: KafkaTemplate<String, String>
 
     @Autowired
     private lateinit var createTimeTableOccupancyService: CreateTimeTableOccupancyService
@@ -158,7 +157,7 @@ class TimeTableOccupiedDomainEventListenerTest {
         createTimeTableOccupancyService.execute(command)
 
         verify(exactly = 1) {
-            kafkaTemplate.send(eq(TIME_TABLE_OCCUPIED.name), any(), any())
+            kafkaTemplate.send(any<ProducerRecord<String, String>>())
         }
     }
 }

--- a/adapter-module/src/test/kotlin/com/reservation/event/timetable/occupancy/TimeTableOccupiedDomainEventListenerTest.kt
+++ b/adapter-module/src/test/kotlin/com/reservation/event/timetable/occupancy/TimeTableOccupiedDomainEventListenerTest.kt
@@ -2,6 +2,7 @@ package com.reservation.event.timetable.occupancy
 
 import com.ninjasquad.springmockk.MockkBean
 import com.ninjasquad.springmockk.SpykBean
+import com.reservation.enumeration.OutboxEventType.TIME_TABLE_OCCUPIED
 import com.reservation.enumeration.TableStatus
 import com.reservation.enumeration.TimeTableConfirmStatus
 import com.reservation.timetable.TimeTable
@@ -88,8 +89,6 @@ class TimeTableOccupiedDomainEventListenerTest {
                 kafkaContainer.bootstrapServers
             }
         }
-
-        private const val EVENT = "TIME_TABLE_OCCUPIED"
     }
 
     @MockkBean
@@ -113,7 +112,7 @@ class TimeTableOccupiedDomainEventListenerTest {
             // Kafka 컨테이너 시작 대기
             Thread.sleep(5000)
             val adminClient = AdminClient.create(kafkaAdmin.configurationProperties)
-            val topic = NewTopic("TIME_TABLE_OCCUPIED", 3, 1)
+            val topic = NewTopic(TIME_TABLE_OCCUPIED.name, 3, 1)
             adminClient.createTopics(listOf(topic)).all().get()
             adminClient.close()
         } catch (e: Exception) {
@@ -157,7 +156,11 @@ class TimeTableOccupiedDomainEventListenerTest {
         createTimeTableOccupancyService.execute(command)
 
         verify(exactly = 1) {
-            kafkaTemplate.send(any<ProducerRecord<String, String>>())
+            kafkaTemplate.send(
+                match<ProducerRecord<String, String>> {
+                    it.topic() == TIME_TABLE_OCCUPIED.name
+                },
+            )
         }
     }
 }

--- a/adapter-module/src/test/kotlin/com/reservation/kafka/listener/TimeTableOccupancyKafkaListenerTest.kt
+++ b/adapter-module/src/test/kotlin/com/reservation/kafka/listener/TimeTableOccupancyKafkaListenerTest.kt
@@ -1,5 +1,6 @@
 package com.reservation.kafka.listener
 
+import com.fasterxml.jackson.databind.ObjectMapper
 import com.navercorp.fixturemonkey.kotlin.giveMeOne
 import com.reservation.common.exceptions.NoSuchPersistedElementException
 import com.reservation.enumeration.OutboxEventType.TIME_TABLE_OCCUPIED
@@ -11,6 +12,7 @@ import com.reservation.kafka.event.TimeTableOccupancyReceivedEvent
 import com.reservation.reservation.port.input.CreateReservationUseCase
 import com.reservation.reservation.port.input.IsReservationExistsUseCase
 import com.reservation.utilities.generator.uuid.UuidGenerator
+import io.confluent.parallelconsumer.ParallelStreamProcessor
 import io.kotest.core.annotation.DisplayName
 import io.kotest.core.spec.style.FunSpec
 import io.mockk.clearAllMocks
@@ -18,9 +20,10 @@ import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
 import net.jqwik.api.Arbitraries
+import org.junit.jupiter.api.assertThrows
 import org.springframework.dao.DataIntegrityViolationException
 import org.springframework.http.ResponseEntity
-import org.springframework.kafka.support.Acknowledgment
+import org.springframework.kafka.core.KafkaTemplate
 import java.time.LocalDateTime
 
 @DisplayName("Kafka Listener로 이벤트를 전달 받았을 때 ")
@@ -29,12 +32,18 @@ class TimeTableOccupancyKafkaListenerTest : FunSpec(
         val httpInterface = mockk<FindTimeTableOccupancyHttpInterface>()
         val createReservationUseCase = mockk<CreateReservationUseCase>()
         val isReservationExistsUseCase = mockk<IsReservationExistsUseCase>()
+        val parallelEventConsumer = mockk<ParallelStreamProcessor<String, String>>(relaxed = true)
+        val objectMapper = ObjectMapper()
+        val kafkaTemplate = mockk<KafkaTemplate<String, String>>(relaxed = true)
 
         val kafkaListener =
             TimeTableOccupancyKafkaListener(
                 httpInterface = httpInterface,
                 createReservationUseCase = createReservationUseCase,
                 isReservationExistsUseCase = isReservationExistsUseCase,
+                parallelEventConsumer = parallelEventConsumer,
+                objectMapper = objectMapper,
+                kafkaTemplate = kafkaTemplate,
             )
 
         val pureMonkey = FixtureMonkeyFactory.giveMePureMonkey().build()
@@ -44,7 +53,6 @@ class TimeTableOccupancyKafkaListenerTest : FunSpec(
         }
 
         test("HttpInterface에서 NoSuchPersistedElementException가 발생한다.") {
-            val ack = mockk<Acknowledgment>(relaxed = true)
             val event =
                 TimeTableOccupancyReceivedEvent(
                     eventType = TIME_TABLE_OCCUPIED,
@@ -56,18 +64,21 @@ class TimeTableOccupancyKafkaListenerTest : FunSpec(
                 )
 
             every {
+                isReservationExistsUseCase.execute(any())
+            } returns false
+
+            every {
                 httpInterface.findTimeTableOccupancyInternally(any(), any())
             } throws NoSuchPersistedElementException()
 
-            kafkaListener.createReservationHandler(ack, event)
+            assertThrows<NoSuchPersistedElementException> {
+                kafkaListener.onEventHandler(event)
+            }
 
             verify(exactly = 1) { httpInterface.findTimeTableOccupancyInternally(any(), any()) }
-            verify(exactly = 0) { ack.acknowledge() }
-            verify(exactly = 1) { ack.nack(any()) }
         }
 
         test("HttpInterface에서 조회가 완료됐지만 예약 생성에 실패한다.") {
-            val ack = mockk<Acknowledgment>(relaxed = true)
             val event =
                 TimeTableOccupancyReceivedEvent(
                     eventType = TIME_TABLE_OCCUPIED,
@@ -81,6 +92,10 @@ class TimeTableOccupancyKafkaListenerTest : FunSpec(
             val response =
                 pureMonkey
                     .giveMeOne<FindTimeTableOccupancyInternallyHttpInterfaceResponse>()
+
+            every {
+                isReservationExistsUseCase.execute(any())
+            } returns false
 
             every {
                 httpInterface.findTimeTableOccupancyInternally(any(), any())
@@ -90,15 +105,14 @@ class TimeTableOccupancyKafkaListenerTest : FunSpec(
                 createReservationUseCase.execute(any())
             } throws DataIntegrityViolationException(Arbitraries.strings().sample())
 
-            kafkaListener.createReservationHandler(ack, event)
+            assertThrows<DataIntegrityViolationException> {
+                kafkaListener.onEventHandler(event)
+            }
 
             verify(exactly = 1) { httpInterface.findTimeTableOccupancyInternally(any(), any()) }
-            verify(exactly = 0) { ack.acknowledge() }
-            verify(exactly = 1) { ack.nack(any()) }
         }
 
         test("HttpInterface에서 조회가 완료됐고 예약 생성에 성공한다.") {
-            val ack = mockk<Acknowledgment>(relaxed = true)
             val event =
                 TimeTableOccupancyReceivedEvent(
                     eventType = TIME_TABLE_OCCUPIED,
@@ -113,6 +127,10 @@ class TimeTableOccupancyKafkaListenerTest : FunSpec(
                     .giveMeOne<FindTimeTableOccupancyInternallyHttpInterfaceResponse>()
 
             every {
+                isReservationExistsUseCase.execute(any())
+            } returns false
+
+            every {
                 httpInterface.findTimeTableOccupancyInternally(any(), any())
             } returns ResponseEntity.ok(response)
 
@@ -120,11 +138,9 @@ class TimeTableOccupancyKafkaListenerTest : FunSpec(
                 createReservationUseCase.execute(any())
             } returns true
 
-            kafkaListener.createReservationHandler(ack, event)
+            kafkaListener.onEventHandler(event)
 
             verify(exactly = 1) { httpInterface.findTimeTableOccupancyInternally(any(), any()) }
-            verify(exactly = 1) { ack.acknowledge() }
-            verify(exactly = 0) { ack.nack(any()) }
         }
     },
 )

--- a/adapter-module/src/test/kotlin/com/reservation/kafka/listener/TimeTableOccupancyKafkaListenerTest.kt
+++ b/adapter-module/src/test/kotlin/com/reservation/kafka/listener/TimeTableOccupancyKafkaListenerTest.kt
@@ -2,12 +2,14 @@ package com.reservation.kafka.listener
 
 import com.navercorp.fixturemonkey.kotlin.giveMeOne
 import com.reservation.common.exceptions.NoSuchPersistedElementException
-import com.reservation.enumeration.OutboxEventType
+import com.reservation.enumeration.OutboxEventType.TIME_TABLE_OCCUPIED
 import com.reservation.fixture.FixtureMonkeyFactory
 import com.reservation.httpinterface.timetable.FindTimeTableOccupancyHttpInterface
 import com.reservation.httpinterface.timetable.response.FindTimeTableOccupancyInternallyHttpInterfaceResponse
-import com.reservation.kafka.listener.event.TimeTableOccupancyReceivedEvent
+import com.reservation.kafka.adapter.TimeTableOccupancyKafkaListener
+import com.reservation.kafka.event.TimeTableOccupancyReceivedEvent
 import com.reservation.reservation.port.input.CreateReservationUseCase
+import com.reservation.reservation.port.input.IsReservationExistsUseCase
 import com.reservation.utilities.generator.uuid.UuidGenerator
 import io.kotest.core.annotation.DisplayName
 import io.kotest.core.spec.style.FunSpec
@@ -26,11 +28,13 @@ class TimeTableOccupancyKafkaListenerTest : FunSpec(
     {
         val httpInterface = mockk<FindTimeTableOccupancyHttpInterface>()
         val createReservationUseCase = mockk<CreateReservationUseCase>()
+        val isReservationExistsUseCase = mockk<IsReservationExistsUseCase>()
 
         val kafkaListener =
             TimeTableOccupancyKafkaListener(
                 httpInterface = httpInterface,
                 createReservationUseCase = createReservationUseCase,
+                isReservationExistsUseCase = isReservationExistsUseCase,
             )
 
         val pureMonkey = FixtureMonkeyFactory.giveMePureMonkey().build()
@@ -43,7 +47,7 @@ class TimeTableOccupancyKafkaListenerTest : FunSpec(
             val ack = mockk<Acknowledgment>(relaxed = true)
             val event =
                 TimeTableOccupancyReceivedEvent(
-                    eventType = OutboxEventType.TIME_TABLE_OCCUPIED,
+                    eventType = TIME_TABLE_OCCUPIED,
                     eventVersion = 1.0,
                     timeTableId = UuidGenerator.generate(),
                     timeTableOccupancyId = UuidGenerator.generate(),
@@ -66,7 +70,7 @@ class TimeTableOccupancyKafkaListenerTest : FunSpec(
             val ack = mockk<Acknowledgment>(relaxed = true)
             val event =
                 TimeTableOccupancyReceivedEvent(
-                    eventType = OutboxEventType.TIME_TABLE_OCCUPIED,
+                    eventType = TIME_TABLE_OCCUPIED,
                     eventVersion = 1.0,
                     timeTableId = UuidGenerator.generate(),
                     timeTableOccupancyId = UuidGenerator.generate(),
@@ -97,7 +101,7 @@ class TimeTableOccupancyKafkaListenerTest : FunSpec(
             val ack = mockk<Acknowledgment>(relaxed = true)
             val event =
                 TimeTableOccupancyReceivedEvent(
-                    eventType = OutboxEventType.TIME_TABLE_OCCUPIED,
+                    eventType = TIME_TABLE_OCCUPIED,
                     eventVersion = 1.0,
                     timeTableId = UuidGenerator.generate(),
                     timeTableOccupancyId = UuidGenerator.generate(),

--- a/application-module/src/main/kotlin/com/reservation/reservation/port/input/IsReservationExistsUseCase.kt
+++ b/application-module/src/main/kotlin/com/reservation/reservation/port/input/IsReservationExistsUseCase.kt
@@ -1,0 +1,7 @@
+package com.reservation.reservation.port.input
+
+import com.reservation.reservation.port.input.query.IsReservationExistsQuery
+
+interface IsReservationExistsUseCase {
+    fun execute(query: IsReservationExistsQuery): Boolean
+}

--- a/application-module/src/main/kotlin/com/reservation/reservation/port/input/query/IsReservationExistsQuery.kt
+++ b/application-module/src/main/kotlin/com/reservation/reservation/port/input/query/IsReservationExistsQuery.kt
@@ -1,0 +1,6 @@
+package com.reservation.reservation.port.input.query
+
+data class IsReservationExistsQuery(
+    val timeTableId: String,
+    val timeTableOccupancyId: String,
+)

--- a/application-module/src/main/kotlin/com/reservation/reservation/port/output/IsReservationExists.kt
+++ b/application-module/src/main/kotlin/com/reservation/reservation/port/output/IsReservationExists.kt
@@ -1,0 +1,10 @@
+package com.reservation.reservation.port.output
+
+interface IsReservationExists {
+    fun query(inquiry: IsReservationExistsInquiry): Boolean
+
+    data class IsReservationExistsInquiry(
+        val timeTableId: String,
+        val timeTableOccupancyId: String,
+    )
+}

--- a/application-module/src/main/kotlin/com/reservation/reservation/usecase/IsReservationExistsService.kt
+++ b/application-module/src/main/kotlin/com/reservation/reservation/usecase/IsReservationExistsService.kt
@@ -1,0 +1,21 @@
+package com.reservation.reservation.usecase
+
+import com.reservation.config.annotations.UseCase
+import com.reservation.reservation.port.input.IsReservationExistsUseCase
+import com.reservation.reservation.port.input.query.IsReservationExistsQuery
+import com.reservation.reservation.port.output.IsReservationExists
+import com.reservation.reservation.port.output.IsReservationExists.IsReservationExistsInquiry
+
+@UseCase
+class IsReservationExistsService(
+    val isReservationExists: IsReservationExists,
+) : IsReservationExistsUseCase {
+    override fun execute(query: IsReservationExistsQuery) =
+        isReservationExists.query(query.toInquiry())
+
+    private fun IsReservationExistsQuery.toInquiry() =
+        IsReservationExistsInquiry(
+            timeTableId = timeTableId,
+            timeTableOccupancyId = timeTableOccupancyId,
+        )
+}

--- a/batch-module/src/test/resources/docker-java.properties
+++ b/batch-module/src/test/resources/docker-java.properties
@@ -1,0 +1,1 @@
+api.version=1.44

--- a/core-module/src/test/kotlin/com/reservation/timetable/CreateTimeTableOccupancyDomainServiceTest.kt
+++ b/core-module/src/test/kotlin/com/reservation/timetable/CreateTimeTableOccupancyDomainServiceTest.kt
@@ -95,7 +95,7 @@ class CreateTimeTableOccupancyDomainServiceTest : BehaviorSpec(
 
         Given("UUID 형식이 아닌 timeTableId를 가진 TimeTable이 주어졌을 때") {
             val userId = UuidGenerator.generate()
-            val timeTableId = Arbitraries.strings().ofLength(128).sample()
+            val timeTableId = Arbitraries.strings().ascii().ofLength(128).sample()
 
             When("예약 점유 생성을 요청하면") {
                 val timetable = giveMePerfectCase(id = timeTableId)


### PR DESCRIPTION
## 🎫 Context- github:
- jira: JIRA-1234

 📄 Summary
- TimeTableOccupancy Kafka consumer를 Confluent ParallelStreamProcessor 기반 병렬 처리로 전환 및 관련 리팩터링

## ✨ What’s Changed
- ParallelConsumerOptions 빌더 제네릭화 및 KafkaConsumer 제네릭 생성으로 타입 안전성 향상
- ParallelStreamProcessor 생성 로직 단순화(옵션 빌더에서 shutdownTimeout 적용 및 build 호출)
- Spring @KafkaListener 제거 및 ParallelStreamProcessor 기반 구독/폴링 로직 추가 (TOPIC: time-table-occupancy)
- JSON 역직렬화 실패 시 DLT 처리 및 처리 실패 재시도/백오프 로직 추가 (RETRY_ATTEMPTS, BACK_OFF_DELAY, BACK_OFF_MULTIPLIER)
- ParallelStreamProcessor 초기화(@PostConstruct) 및 종료(@PreDestroy)(draining close) 구현
- KafkaTemplate, ObjectMapper, 로거 주입 및 필요 import 정리
- 테스트 리팩터링: TimeTableOccupancyKafkaListenerTest를 ParallelStreamProcessor/ObjectMapper/KafkaTemplate 목으로 변경, Acknowledgment 기반 테스트 제거
- 신규 포트 추가: IsReservationExists 출력 포트 및 관련 inquiry 데이터 클래스

## 🧩 Motivation & Background
- 병렬 소비로 처리량 및 안정성 향상, 에러 시 DLT로 전송 및 재시도 정책 적용 필요

## 🔥 Impact
- 기존 @KafkaListener 기반 처리 제거로 소비 방식이 변경됨
- 구성 타입 안전성 향상 및 재시도/DLT 처리 도입으로 장애 대응 방식 변경
- 테스트 코드와 의존성 목 변경 필요

## 🚦 How to Test (검증방법)
- ParallelStreamProcessor 초기화/종료 시점 검증
- 정상 메시지 처리 흐름 검증
- JSON 역직렬화 실패 메시지가 DLT로 전송되는지 검증
- 실패 시 재시도 횟수와 백오프 동작 검증
- IsReservationExists 포트 호출 및 반환 시 동작 검증

## 📝 Notes

- 참고/리뷰 요청/논의 사항 등