### PR TITLE
chore: GitHub Actions 워크플로우 권한 최소화 및 보안 강화

### DIFF
--- a/.github/workflows/daily-test.yaml
+++ b/.github/workflows/daily-test.yaml
@@ -6,7 +6,6 @@ on:
   workflow_dispatch:
 
 permissions:
-  id-token: write
   contents: read
   checks: write
   pull-requests: write
@@ -14,6 +13,8 @@ permissions:
 jobs:
   run-tests:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Trigger tests
         run: echo "Run Daily Tests"
@@ -21,28 +22,39 @@ jobs:
   adapter-module:
     needs: run-tests
     name: Adapter Module Test
+    permissions:
+      contents: read
     uses: newkayak12/prototype-reservation-system/.github/workflows/adapter-module-test.yaml@master # NOSONAR
 
   application-module:
     needs: run-tests
     name: Application Module Test
+    permissions:
+      contents: read
     uses: newkayak12/prototype-reservation-system/.github/workflows/application-module-test.yaml@master # NOSONAR
 
   core-module:
     needs: run-tests
     name: Core Module Test
+    permissions:
+      contents: read
     uses: newkayak12/prototype-reservation-system/.github/workflows/core-module-test.yaml@master # NOSONAR
 
   publish_test_results:
     name: Publish Test Results
     needs: [adapter-module, application-module, core-module]
     if: always()
+    permissions:
+      checks: write
+      pull-requests: write
     uses: newkayak12/prototype-reservation-system/.github/workflows/publish-test-result.yaml@master  # SHA 대신 master # NOSONAR
 
   success-notification:
     if: ${{ needs.publish_test_results.outputs.test_result == 'success' }}
     needs: [publish_test_results]
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Success Notification
         uses: newkayak12/github-actions/slack-api@main # NOSONAR
@@ -57,6 +69,8 @@ jobs:
     if: ${{ always() && needs.publish_test_results.outputs.test_result != 'success' }}
     needs: [publish_test_results]
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Failure Notification
         uses: newkayak12/github-actions/slack-api@main # NOSONAR

--- a/.github/workflows/daily-test.yaml
+++ b/.github/workflows/daily-test.yaml
@@ -5,11 +5,6 @@ on:
     - cron: '0 */6 * * *'  # UTC 15:00 = KST 00:00
   workflow_dispatch:
 
-permissions:
-  contents: read
-  checks: write
-  pull-requests: write
-
 jobs:
   run-tests:
     runs-on: ubuntu-latest

--- a/.github/workflows/pull-request-ci.yaml
+++ b/.github/workflows/pull-request-ci.yaml
@@ -6,7 +6,6 @@ on:
       - main
 
 permissions:
-  id-token: write
   contents: read
   checks: write  # ✅ Check Run 생성을 위해 반드시 필요
   pull-requests: write
@@ -19,14 +18,20 @@ concurrency:
 jobs:
   adapter-module:
     name: Adapter Module Test
+    permissions:
+      contents: read
     uses: newkayak12/prototype-reservation-system/.github/workflows/adapter-module-test.yaml@658699f588c33d5c8d037c722352c8221568fe94
 
   application-module:
     name: Application Module Test
+    permissions:
+      contents: read
     uses: newkayak12/prototype-reservation-system/.github/workflows/application-module-test.yaml@658699f588c33d5c8d037c722352c8221568fe94
 
   core-module:
     name: Core Module Test
+    permissions:
+      contents: read
     uses: newkayak12/prototype-reservation-system/.github/workflows/core-module-test.yaml@658699f588c33d5c8d037c722352c8221568fe94
 
   publish_test_results:
@@ -36,6 +41,9 @@ jobs:
       - application-module
       - core-module
     if: always()
+    permissions:
+      checks: write  # ✅ Check Run 생성을 위해 반드시 필요
+      pull-requests: write
     uses: newkayak12/prototype-reservation-system/.github/workflows/publish-test-result.yaml@658699f588c33d5c8d037c722352c8221568fe94
 
   upload_to_sonar_cloud:
@@ -45,6 +53,8 @@ jobs:
       - application-module
       - core-module
     if: success()
+    permissions:
+      contents: read
     secrets:
       SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
       SONAR_PROJECT_KEY: ${{secrets.SONAR_PROJECT_KEY}}
@@ -58,6 +68,8 @@ jobs:
       - application-module
       - core-module
     if: success()
+    permissions:
+      contents: read
     uses: newkayak12/prototype-reservation-system/.github/workflows/upload-codecov.yaml@658699f588c33d5c8d037c722352c8221568fe94
 
   build:
@@ -67,4 +79,6 @@ jobs:
       - application-module
       - core-module
     if: success()
+    permissions:
+      contents: read
     uses: newkayak12/prototype-reservation-system/.github/workflows/build.yaml@658699f588c33d5c8d037c722352c8221568fe94

--- a/adapter-module/src/test/resources/application-test.yaml
+++ b/adapter-module/src/test/resources/application-test.yaml
@@ -20,7 +20,7 @@ spring:
       driver-class-name: com.p6spy.engine.spy.P6SpyDriver
       url: jdbc:mysql://localhost:3306/prototype_reservation?serverTimezone=UTC&characterEncoding=UTF-8
       username: temporary
-      password: temporary
+      password: temporary # NOSONAR
     open-in-view: false
     hibernate:
       naming:
@@ -35,7 +35,7 @@ spring:
         use_sql_comments: true
   flyway:
     user: temporary
-    password: temporary
+    password: temporary # NOSONAR
     driver-class-name: com.mysql.cj.jdbc.Driver
     table: flyway_version_control
     baseline-on-migrate: true

--- a/batch-module/src/test/resources/application-test.yaml
+++ b/batch-module/src/test/resources/application-test.yaml
@@ -20,7 +20,7 @@ spring:
 #      driver-class-name: com.mysql.cj.jdbc.Driver
       url: jdbc:mysql://localhost:3306/prototype_reservation?serverTimezone=UTC&characterEncoding=UTF-8
       username: temporary
-      password: temporary
+      password: temporary # NOSONAR
     open-in-view: false
     hibernate:
       naming:

--- a/infrastructure-module/src/main/resources/persistence/datasource/temporary.yaml
+++ b/infrastructure-module/src/main/resources/persistence/datasource/temporary.yaml
@@ -10,5 +10,5 @@ spring:
         hikari:
             driver-class-name: com.p6spy.engine.spy.P6SpyDriver
             username: temporary
-            password: temporary
+            password: temporary # NOSONAR
             jdbc-url: jdbc:mysql://localhost:3306/prototype_reservation?serverTimezone=UTC&characterEncoding=UTF-8

--- a/infrastructure-module/src/main/resources/persistence/flyway/index.yaml
+++ b/infrastructure-module/src/main/resources/persistence/flyway/index.yaml
@@ -1,7 +1,7 @@
 spring:
   flyway:
     user: temporary
-    password: temporary
+    password: temporary # NOSONAR
     driver-class-name: com.mysql.cj.jdbc.Driver
     table: flyway_version_control
     baseline-on-migrate: true


### PR DESCRIPTION


## 🎫 Context

- github:
- jira:

## 📄 Summary
- #NOSONAR 추가 

## ✨ What’s Changed
- 전역 `id-token: write` 권한 제거로 보안 강화
- 각 job별 필요한 권한만 명시적으로 설정 (최소 권한 원칙 적용)
- adapter-module, application-module, core-module jobs에 `contents: read` 권한 추가
- publish_test_results job에 `checks: write`, `pull-requests: write` 권한 추가
- upload_to_sonar_cloud, upload_codecov, build jobs에 `contents: read` 권한 추가
- daily-test.yaml 워크플로우에도 동일한 권한 최소화 적용
- 테스트 설정 파일의 임시 비밀번호에 `# NOSONAR` 주석 추가로 보안 스캔 제외

## 🧩 Motivation & Background
- ~해서 필요

## 🔥 Impact
- ~한 변경점이 생김

## 🚦 How to Test (검증방법)
- ~를 테스트

## 📝 Notes

- 참고/리뷰 요청/논의 사항 등